### PR TITLE
fix/race: Fix a data race access to the moving average pointer

### DIFF
--- a/gateway/upstreamer/push/movingaverage.go
+++ b/gateway/upstreamer/push/movingaverage.go
@@ -41,15 +41,21 @@ func (m movingAverage) average() (float64, error) {
 	return sum / float64(m.sampleSize), nil
 }
 
-// insertValue will insert a new value to the ring and return a copy
+// append will insert a new value to the ring and return a copy
 // of itself
-func (m movingAverage) insertValue(value float64) movingAverage {
+func (m movingAverage) append(value float64) movingAverage {
 
-	m.ring[m.nextIdx] = value
-	m.nextIdx = (m.nextIdx + 1) % m.sampleSize
-	if m.nextIdx == 0 {
-		m.samplingComplete = true
+	nm := newMovingAverage(m.sampleSize)
+
+	for i := range m.ring {
+		nm.ring[i] = m.ring[i]
 	}
 
-	return m
+	nm.nextIdx = (m.nextIdx + 1) % nm.sampleSize
+	nm.ring[nm.nextIdx] = value
+	if nm.nextIdx == 0 {
+		nm.samplingComplete = true
+	}
+
+	return nm
 }

--- a/gateway/upstreamer/push/movingaverage.go
+++ b/gateway/upstreamer/push/movingaverage.go
@@ -12,13 +12,13 @@ type movingAverage struct {
 }
 
 // newMovingAverage return a new movingAverage
-func newMovingAverage(sampleSize int) *movingAverage {
+func newMovingAverage(sampleSize int) movingAverage {
 
 	if sampleSize <= 0 {
 		panic("sampleSize must be greather than 0.")
 	}
 
-	return &movingAverage{
+	return movingAverage{
 		sampleSize: sampleSize,
 		ring:       make([]float64, sampleSize),
 	}
@@ -26,7 +26,7 @@ func newMovingAverage(sampleSize int) *movingAverage {
 
 // average return the average of the sampleSize
 // If sampleSize are not compplete it returns 0
-func (m *movingAverage) average() (float64, error) {
+func (m movingAverage) average() (float64, error) {
 
 	sum := .0
 
@@ -41,12 +41,15 @@ func (m *movingAverage) average() (float64, error) {
 	return sum / float64(m.sampleSize), nil
 }
 
-// insertValue will insert a new value to the ring.
-func (m *movingAverage) insertValue(value float64) {
+// insertValue will insert a new value to the ring and return a copy
+// of itself
+func (m movingAverage) insertValue(value float64) movingAverage {
 
 	m.ring[m.nextIdx] = value
 	m.nextIdx = (m.nextIdx + 1) % m.sampleSize
 	if m.nextIdx == 0 {
 		m.samplingComplete = true
 	}
+
+	return m
 }

--- a/gateway/upstreamer/push/movingaverage_test.go
+++ b/gateway/upstreamer/push/movingaverage_test.go
@@ -18,27 +18,27 @@ func TestMovingAverage(t *testing.T) {
 		})
 
 		Convey("When I push two values the average is not available", func() {
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("When I push a tree values the average calculated", func() {
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 1)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("When I push a four values the average calculated", func() {
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
-			ma = ma.insertValue(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
+			ma = ma.append(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 1)
 			So(err, ShouldBeNil)

--- a/gateway/upstreamer/push/movingaverage_test.go
+++ b/gateway/upstreamer/push/movingaverage_test.go
@@ -18,27 +18,27 @@ func TestMovingAverage(t *testing.T) {
 		})
 
 		Convey("When I push two values the average is not available", func() {
-			ma.insertValue(1)
-			ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("When I push a tree values the average calculated", func() {
-			ma.insertValue(1)
-			ma.insertValue(1)
-			ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 1)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("When I push a four values the average calculated", func() {
-			ma.insertValue(1)
-			ma.insertValue(1)
-			ma.insertValue(1)
-			ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
+			ma = ma.insertValue(1)
 			v, err := ma.average()
 			So(v, ShouldEqual, 1)
 			So(err, ShouldBeNil)

--- a/gateway/upstreamer/push/upstreamer.go
+++ b/gateway/upstreamer/push/upstreamer.go
@@ -174,13 +174,13 @@ func (c *Upstreamer) Upstream(req *http.Request) (string, error) {
 
 	// fill our weight from the Feedbackloop
 	if ma, ok := c.latencies.Load(addresses[0]); ok {
-		if v, err := ma.(*movingAverage).average(); err == nil {
+		if v, err := ma.(movingAverage).average(); err == nil {
 			w[0] = v
 		}
 	}
 
 	if ma, ok := c.latencies.Load(addresses[1]); ok {
-		if v, err := ma.(*movingAverage).average(); err == nil {
+		if v, err := ma.(movingAverage).average(); err == nil {
 			w[1] = v
 		}
 	}
@@ -540,7 +540,7 @@ func (c *Upstreamer) listenPeers(ctx context.Context) {
 func (c *Upstreamer) CollectLatency(address string, responseTime time.Duration) {
 
 	if values, ok := c.latencies.Load(address); ok {
-		values.(*movingAverage).insertValue(float64(responseTime.Microseconds()))
+		c.latencies.Store(address, values.(movingAverage).insertValue(float64(responseTime.Microseconds())))
 	} else {
 		c.latencies.Store(address, newMovingAverage(c.config.latencySampleSize))
 		c.CollectLatency(address, responseTime)

--- a/gateway/upstreamer/push/upstreamer.go
+++ b/gateway/upstreamer/push/upstreamer.go
@@ -540,7 +540,7 @@ func (c *Upstreamer) listenPeers(ctx context.Context) {
 func (c *Upstreamer) CollectLatency(address string, responseTime time.Duration) {
 
 	if values, ok := c.latencies.Load(address); ok {
-		c.latencies.Store(address, values.(movingAverage).insertValue(float64(responseTime.Microseconds())))
+		c.latencies.Store(address, values.(movingAverage).append(float64(responseTime.Microseconds())))
 	} else {
 		c.latencies.Store(address, newMovingAverage(c.config.latencySampleSize))
 		c.CollectLatency(address, responseTime)

--- a/gateway/upstreamer/push/upstreamer_distribution_test.go
+++ b/gateway/upstreamer/push/upstreamer_distribution_test.go
@@ -3,6 +3,7 @@ package push
 import (
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -158,7 +159,7 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("When I add two entries the average is not yet available", func() {
+		Convey("When I add two entries the average is available", func() {
 			u.CollectLatency("bar", 1*time.Microsecond)
 			u.CollectLatency("bar", 1*time.Microsecond)
 
@@ -171,6 +172,33 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 
 			So(v, ShouldEqual, 1)
 			So(err, ShouldBeNil)
+		})
+
+		Convey("When I add entries concurently there is no race", func() {
+
+			u := NewUpstreamer(nil, "topic", "topic2")
+			u.config.latencySampleSize = 100
+
+			var wg sync.WaitGroup
+
+			inc := func() {
+				defer wg.Done()
+				u.CollectLatency("bar", 1*time.Microsecond)
+			}
+
+			for i := 0; i < 100; i++ {
+				wg.Add(1)
+				go inc()
+			}
+
+			wg.Wait()
+
+			if ma, ok := u.latencies.Load("bar"); ok {
+				// As there is no garrantee of the result as the operation can overlap
+				// we are not checking the result here. This is just to track races
+				_, _ = ma.(movingAverage).average()
+			}
+
 		})
 
 		Convey("When I delete an entry a values the average is not available", func() {

--- a/gateway/upstreamer/push/upstreamer_distribution_test.go
+++ b/gateway/upstreamer/push/upstreamer_distribution_test.go
@@ -137,7 +137,7 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 			var err error
 
 			if ma, ok := u.latencies.Load("foo"); ok {
-				v, err = ma.(*movingAverage).average()
+				v, err = ma.(movingAverage).average()
 			}
 
 			So(v, ShouldEqual, 0)
@@ -151,7 +151,7 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 			var err error
 
 			if ma, ok := u.latencies.Load("bar"); ok {
-				v, err = ma.(*movingAverage).average()
+				v, err = ma.(movingAverage).average()
 			}
 
 			So(v, ShouldEqual, 0)
@@ -166,7 +166,7 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 			var err error
 
 			if ma, ok := u.latencies.Load("bar"); ok {
-				v, err = ma.(*movingAverage).average()
+				v, err = ma.(movingAverage).average()
 			}
 
 			So(v, ShouldEqual, 1)
@@ -179,7 +179,7 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 			var err error
 
 			if ma, ok := u.latencies.Load("bar"); ok {
-				v, err = ma.(*movingAverage).average()
+				v, err = ma.(movingAverage).average()
 			}
 
 			So(v, ShouldEqual, 0)


### PR DESCRIPTION
## Description

```
WARNING: DATA RACE
Read at 0x00c0007e1a90 by goroutine 235:
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*movingAverage).insertValue()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/movingaverage.go:47 +0x105
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*Upstreamer).CollectLatency()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/upstreamer.go:543 +0x9d
  go.aporeto.io/bahamut/gateway.(*gateway).ServeHTTP()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:540 +0x160c
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2887 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1952 +0x87d

Previous write at 0x00c0007e1a90 by goroutine 223:
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*movingAverage).insertValue()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/movingaverage.go:48 +0x1da
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*Upstreamer).CollectLatency()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/upstreamer.go:543 +0x9d
  go.aporeto.io/bahamut/gateway.(*gateway).ServeHTTP()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:540 +0x160c
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2887 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1952 +0x87d

Goroutine 235 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3013 +0x644
  go.aporeto.io/bahamut/gateway.(*gateway).Start.func1()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:262 +0x9c

Goroutine 223 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3013 +0x644
  go.aporeto.io/bahamut/gateway.(*gateway).Start.func1()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:262 +0x9c
==================
==================
WARNING: DATA RACE
Write at 0x00c00065e0a0 by goroutine 137:
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*movingAverage).insertValue()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/movingaverage.go:47 +0x158
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*Upstreamer).CollectLatency()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/upstreamer.go:543 +0x9d
  go.aporeto.io/bahamut/gateway.(*gateway).ServeHTTP()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:540 +0x160c
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2887 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1952 +0x87d

Previous write at 0x00c00065e0a0 by goroutine 673:
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*movingAverage).insertValue()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/movingaverage.go:47 +0x158
  go.aporeto.io/bahamut/gateway/upstreamer/push.(*Upstreamer).CollectLatency()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/upstreamer/push/upstreamer.go:543 +0x9d
  go.aporeto.io/bahamut/gateway.(*gateway).ServeHTTP()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:540 +0x160c
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2887 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1952 +0x87d

Goroutine 137 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3013 +0x644
  go.aporeto.io/bahamut/gateway.(*gateway).Start.func1()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:262 +0x9c

Goroutine 673 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3013 +0x644
  go.aporeto.io/bahamut/gateway.(*gateway).Start.func1()
      /tmp/build/ae5c2d4a/go/pkg/mod/go.aporeto.io/bahamut@v1.112.1-0.20210511234020-d223af0361d8/gateway/gateway.go:262 +0x9c
==================
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist


- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
