### PR TITLE
Update: Support go 1.17 and split linter version

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -19,8 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.15
+          - 1.17
           - 1.16
+          - 1.15
     steps:
       - uses: actions/checkout@v2
 
@@ -28,10 +29,23 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: setup-for-old-go
+        if: ${{ matrix.go < 1.17 }}
+        run: |
+          # stay on an old version of golangci-lint which still reports properly
+          #
+          # see release notes and this file for detail:
+          # https://github.com/golangci/golangci-lint/blob/v1.43.0/.github/workflows/pr.yml#L67-70
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+
+      - name: setup-for-current-go
+        if: ${{ matrix.go >= 1.17 }}
+        run: |
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
       - name: setup
         run: |
           go version
-          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           go get github.com/securego/gosec/cmd/gosec
           #go get golang.org/x/tools/cmd/cover
           go get github.com/axw/gocov/gocov


### PR DESCRIPTION
## Description
Work towards support go 1.17.x while keeping older support.