### PR TITLE
fixed: status code overwritten to No Content even if user set it before

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -41,6 +41,7 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 	}()
 
 	response.StatusCode = ctx.statusCode
+	var statusCodeWasUnset bool
 	if response.StatusCode == 0 {
 		switch ctx.request.Operation {
 		case elemental.OperationInfo:
@@ -48,6 +49,7 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 		default:
 			response.StatusCode = http.StatusOK
 		}
+		statusCodeWasUnset = true
 	}
 
 	if ctx.request.Operation == elemental.OperationRetrieveMany || ctx.request.Operation == elemental.OperationInfo {
@@ -69,7 +71,9 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 	}
 
 	if ctx.outputData == nil {
-		response.StatusCode = http.StatusNoContent
+		if statusCodeWasUnset || ctx.statusCode == http.StatusOK {
+			response.StatusCode = http.StatusNoContent
+		}
 		return response
 	}
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -176,7 +176,32 @@ func TestHandlers_makeResponse(t *testing.T) {
 			})
 		})
 
-		Convey("When I set the operation to Create, status code OK, but no data, and I call makeResponse", func() {
+		Convey("When I set the operation to Create, no status code and no data, and I call makeResponse", func() {
+
+			ctx.request.Operation = elemental.OperationCreate
+			ctx.outputData = nil
+
+			makeResponse(ctx, response, nil)
+
+			Convey("Then response.StatusCode should be http.StatusNoContent", func() {
+				So(response.StatusCode, ShouldEqual, http.StatusNoContent)
+			})
+		})
+
+		Convey("When I set the operation to Create, status code set and no data, and I call makeResponse", func() {
+
+			ctx.request.Operation = elemental.OperationCreate
+			ctx.statusCode = http.StatusTeapot
+			ctx.outputData = nil
+
+			makeResponse(ctx, response, nil)
+
+			Convey("Then response.StatusCode should be http.StatusTeapot", func() {
+				So(response.StatusCode, ShouldEqual, http.StatusTeapot)
+			})
+		})
+
+		Convey("When I set the operation to Create, status code set to OK and no data, and I call makeResponse", func() {
 
 			ctx.request.Operation = elemental.OperationCreate
 			ctx.statusCode = http.StatusOK


### PR DESCRIPTION
Previously when calling context.SetStatusCode and not having any output data was always overwrite to No Content. This patch ensure that No content is set only if the user did not set a custom code or set to status ok