### PR TITLE
Relax custom routes handlers

### DIFF
--- a/bahamut.go
+++ b/bahamut.go
@@ -170,17 +170,6 @@ func (b *server) UnregisterProcessor(identity elemental.Identity) error {
 
 func (b *server) RegisterCustomRouteHandler(path string, handler http.HandlerFunc) error {
 
-	if !(b.restServer != nil &&
-		b.cfg.restServer.apiPrefix != "" &&
-		b.cfg.restServer.customRoutePrefix != "" &&
-		b.cfg.restServer.apiPrefix != b.cfg.restServer.customRoutePrefix) {
-		return fmt.Errorf(
-			"API root path '%s' and custom handler path '%s' must not overlap",
-			b.cfg.restServer.apiPrefix,
-			b.cfg.restServer.customRoutePrefix,
-		)
-	}
-
 	if _, ok := b.customRoutesHandlers[path]; ok {
 		return fmt.Errorf("path %s has a registered handler already", path)
 	}

--- a/bahamut_test.go
+++ b/bahamut_test.go
@@ -322,26 +322,6 @@ func TestBahamut_RegisterCustomRouteHandlers(t *testing.T) {
 
 		Convey("When I try to register a new custom handler", func() {
 
-			Convey("If rest server is not enabled, it should fail", func() {
-				b := NewServer(config{})
-				So(b.RegisterCustomRouteHandler("/custom", nil), ShouldNotBeNil)
-			})
-
-			Convey("if the rest server is enabled, but the API prefix is empty is empty it should fail", func() {
-				cfg := config{}
-				cfg.restServer.enabled = true
-				b := NewServer(cfg)
-				So(b.RegisterCustomRouteHandler("/custom", nil), ShouldNotBeNil)
-			})
-
-			Convey("if the customRoute prefix is empty, it should fail", func() {
-				cfg := config{}
-				cfg.restServer.enabled = true
-				cfg.restServer.apiPrefix = "/api"
-				b := NewServer(cfg)
-				So(b.RegisterCustomRouteHandler("/custom", nil), ShouldNotBeNil)
-			})
-
 			Convey("When both prefixes are set, I should be able to register it", func() {
 				cfg := config{}
 				cfg.restServer.enabled = true

--- a/handlers.go
+++ b/handlers.go
@@ -41,6 +41,7 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 	}()
 
 	response.StatusCode = ctx.statusCode
+	var statusCodeWasUnset bool
 	if response.StatusCode == 0 {
 		switch ctx.request.Operation {
 		case elemental.OperationInfo:
@@ -48,6 +49,7 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 		default:
 			response.StatusCode = http.StatusOK
 		}
+		statusCodeWasUnset = true
 	}
 
 	if ctx.request.Operation == elemental.OperationRetrieveMany || ctx.request.Operation == elemental.OperationInfo {
@@ -69,7 +71,9 @@ func makeResponse(ctx *bcontext, response *elemental.Response, marshallers map[e
 	}
 
 	if ctx.outputData == nil {
-		response.StatusCode = http.StatusNoContent
+		if statusCodeWasUnset || ctx.statusCode == http.StatusOK {
+			response.StatusCode = http.StatusNoContent
+		}
 		return response
 	}
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -176,7 +176,32 @@ func TestHandlers_makeResponse(t *testing.T) {
 			})
 		})
 
-		Convey("When I set the operation to Create, status code OK, but no data, and I call makeResponse", func() {
+		Convey("When I set the operation to Create, no status code and no data, and I call makeResponse", func() {
+
+			ctx.request.Operation = elemental.OperationCreate
+			ctx.outputData = nil
+
+			makeResponse(ctx, response, nil)
+
+			Convey("Then response.StatusCode should be http.StatusNoContent", func() {
+				So(response.StatusCode, ShouldEqual, http.StatusNoContent)
+			})
+		})
+
+		Convey("When I set the operation to Create, status code set and no data, and I call makeResponse", func() {
+
+			ctx.request.Operation = elemental.OperationCreate
+			ctx.statusCode = http.StatusTeapot
+			ctx.outputData = nil
+
+			makeResponse(ctx, response, nil)
+
+			Convey("Then response.StatusCode should be http.StatusTeapot", func() {
+				So(response.StatusCode, ShouldEqual, http.StatusTeapot)
+			})
+		})
+
+		Convey("When I set the operation to Create, status code set to OK and no data, and I call makeResponse", func() {
 
 			ctx.request.Operation = elemental.OperationCreate
 			ctx.statusCode = http.StatusOK

--- a/rest_server.go
+++ b/rest_server.go
@@ -167,6 +167,12 @@ func (a *restServer) installRoutes(routesInfo map[int][]RouteInfo) {
 		}))
 	}
 
+	if a.customHandlers != nil {
+		for customRoute, f := range a.customHandlers() {
+			a.multiplexer.Handle(path.Join(a.cfg.restServer.customRoutePrefix, customRoute), f)
+		}
+	}
+
 	// non versioned routes
 	a.multiplexer.Get(path.Join(a.cfg.restServer.apiPrefix, "/:category/:id"), a.makeHandler(handleRetrieve))
 	a.multiplexer.Put(path.Join(a.cfg.restServer.apiPrefix, "/:category/:id"), a.makeHandler(handleUpdate))
@@ -191,11 +197,6 @@ func (a *restServer) installRoutes(routesInfo map[int][]RouteInfo) {
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:category"), a.makeHandler(handleInfo))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleInfo))
 
-	if a.customHandlers != nil {
-		for customRoute, f := range a.customHandlers() {
-			a.multiplexer.Handle(path.Join(a.cfg.restServer.customRoutePrefix, customRoute), f)
-		}
-	}
 }
 
 func (a *restServer) start(ctx context.Context, routesInfo map[int][]RouteInfo) {


### PR DESCRIPTION
This patch removes additional checks when registering custom route handlers. Previously it was not possible to overwrite API routes or use the same prefix. Now users are responsible for managing their custom routes if they decide not to use a custom route prefix giving more flexibility in custom handling