### PR TITLE
fixed/mocksession: missing interface method DirectPush

### DIFF
--- a/websocket_push_session_mock.go
+++ b/websocket_push_session_mock.go
@@ -8,6 +8,8 @@ import (
 	"go.aporeto.io/elemental"
 )
 
+var _ PushSession = &MockSession{}
+
 // A MockSession can be used to mock a bahamut.Session.
 type MockSession struct {
 	MockClaims             []string
@@ -21,6 +23,7 @@ type MockSession struct {
 	MockPushConfig         *elemental.PushConfig
 	MockTLSConnectionState *tls.ConnectionState
 	MockToken              string
+	MockDirectPush         func(...*elemental.Event)
 }
 
 // NewMockSession returns a new MockSession.
@@ -44,41 +47,48 @@ func (s *MockSession) Cookie(c string) (*http.Cookie, error) {
 	return v, nil
 }
 
-// Identifier is part of the Session interface.
+// DirectPush is part of the PushSession interface
+func (s *MockSession) DirectPush(evts ...*elemental.Event) {
+	if s.MockDirectPush != nil {
+		s.MockDirectPush(evts...)
+	}
+}
+
+// Identifier is part of the PushSession interface.
 func (s *MockSession) Identifier() string { return s.MockIdentifier }
 
-// Parameter is part of the Session interface.
+// Parameter is part of the PushSession interface.
 func (s *MockSession) Parameter(k string) string { return s.MockParameters[k] }
 
-// Header is part of the Session interface.
+// Header is part of the PushSession interface.
 func (s *MockSession) Header(k string) string { return s.MockHeaders[k] }
 
-// PushConfig is part of the Session interface.
+// PushConfig is part of the PushSession interface.
 func (s *MockSession) PushConfig() *elemental.PushConfig { return s.MockPushConfig }
 
-// SetClaims is part of the Session interface.
+// SetClaims is part of the PushSession interface.
 func (s *MockSession) SetClaims(claims []string) { s.MockClaims = claims }
 
-// Claims is part of the Session interface.
+// Claims is part of the PushSession interface.
 func (s *MockSession) Claims() []string { return s.MockClaims }
 
-// ClaimsMap is part of the Session interface.
+// ClaimsMap is part of the PushSession interface.
 func (s *MockSession) ClaimsMap() map[string]string { return s.MockClaimsMap }
 
-// Token is part of the Session interface.
+// Token is part of the PushSession interface.
 func (s *MockSession) Token() string { return s.MockToken }
 
-// TLSConnectionState is part of the Session interface.
+// TLSConnectionState is part of the PushSession interface.
 func (s *MockSession) TLSConnectionState() *tls.ConnectionState { return s.MockTLSConnectionState }
 
-// Metadata is part of the Session interface.
+// Metadata is part of the PushSession interface.
 func (s *MockSession) Metadata() interface{} { return s.MockMetadata }
 
-// SetMetadata is part of the Session interface.
+// SetMetadata is part of the PushSession interface.
 func (s *MockSession) SetMetadata(m interface{}) { s.MockMetadata = m }
 
-// Context is part of the Session interface.
+// Context is part of the PushSession interface.
 func (s *MockSession) Context() context.Context { return context.Background() }
 
-// ClientIP is part of the Session interface.
+// ClientIP is part of the PushSession interface.
 func (s *MockSession) ClientIP() string { return s.MockClientIP }

--- a/websocket_push_session_mock_test.go
+++ b/websocket_push_session_mock_test.go
@@ -30,6 +30,9 @@ func TestMockSession(t *testing.T) {
 		s.MockTLSConnectionState = &tls.ConnectionState{}
 		s.MockToken = "token"
 
+		var calledDirectPush bool
+		s.MockDirectPush = func(evts ...*elemental.Event) { calledDirectPush = true }
+
 		s.SetClaims([]string{"k=v"})
 		s.SetMetadata("mischief") // A beer to the one who gets the reference.
 
@@ -51,5 +54,8 @@ func TestMockSession(t *testing.T) {
 		cc, err = s.Cookie("d")
 		So(cc, ShouldBeNil)
 		So(err, ShouldEqual, http.ErrNoCookie)
+
+		s.DirectPush()
+		So(calledDirectPush, ShouldBeTrue)
 	})
 }


### PR DESCRIPTION
This patch fixes the MockPushSession missing PushSession interface method DirectPush