### PR TITLE
new: added unified cors policy management and allow standalone server…

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,7 +111,7 @@ type config struct {
 		sessionAuthenticators []SessionAuthenticator
 		authorizers           []Authorizer
 		auditer               Auditer
-		accessControl         *CORSAccessControlPolicy
+		corsController        CORSPolicyController
 	}
 
 	rateLimiting struct {

--- a/config.go
+++ b/config.go
@@ -111,6 +111,7 @@ type config struct {
 		sessionAuthenticators []SessionAuthenticator
 		authorizers           []Authorizer
 		auditer               Auditer
+		accessControl         *CORSAccessControlPolicy
 	}
 
 	rateLimiting struct {

--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,122 @@
+package bahamut
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// CORSOriginMirror instruts to mirror any incoming origin.
+// This should not be used in production as this is a development
+// feature that is not secure.
+const CORSOriginMirror = "_mirror_"
+
+// CORSAccessControlPolicy allows to configure
+// CORS Access Control header of a response.
+type CORSAccessControlPolicy struct {
+	AllowHeaders     []string
+	AllowMethods     []string
+	MaxAge           int
+	AllowOrigin      string
+	ExposeHeaders    []string
+	AllowCredentials bool
+
+	additionalOrigins map[string]struct{}
+}
+
+// NewDefaultCORSAccessControlPolicy returns an CORSAccessControl with default values.
+func NewDefaultCORSAccessControlPolicy(origin string, additionalOrigins []string) *CORSAccessControlPolicy {
+
+	additionalOriginsMap := make(map[string]struct{}, len(additionalOrigins))
+	if len(additionalOrigins) > 0 {
+		for _, o := range additionalOrigins {
+			additionalOriginsMap[o] = struct{}{}
+		}
+	}
+
+	return &CORSAccessControlPolicy{
+		AllowOrigin:       origin,
+		additionalOrigins: additionalOriginsMap,
+		AllowCredentials:  true,
+		MaxAge:            1500,
+		AllowHeaders: []string{
+			"Authorization",
+			"Accept",
+			"Content-Type",
+			"Cache-Control",
+			"Cookie",
+			"If-Modified-Since",
+			"X-Requested-With",
+			"X-Count-Total",
+			"X-Namespace",
+			"X-External-Tracking-Type",
+			"X-External-Tracking-ID",
+			"X-TLS-Client-Certificate",
+			"Accept-Encoding",
+			"X-Fields",
+			"X-Read-Consistency",
+			"X-Write-Consistency",
+			"Idempotency-Key",
+		},
+		AllowMethods: []string{
+			"GET",
+			"POST",
+			"PUT",
+			"DELETE",
+			"PATCH",
+			"HEAD",
+			"OPTIONS",
+		},
+		ExposeHeaders: []string{
+			"X-Requested-With",
+			"X-Count-Total",
+			"X-Namespace",
+			"X-Messages",
+			"X-Fields",
+			"X-Next",
+		},
+	}
+}
+
+// Inject injects the CORS header on the given http.Header. It will use
+// the given request origin to determine the allow origin policy and the method
+// to determine if it should inject pre-flight OPTIONS header.
+// If the given http.Header is nil, this function is a no op.
+func (a *CORSAccessControlPolicy) Inject(h http.Header, origin string, preflight bool) {
+
+	if h == nil {
+		return
+	}
+
+	corsOrigin := a.AllowOrigin
+
+	switch {
+	case a.AllowOrigin == "*":
+		corsOrigin = "*"
+
+	case a.AllowOrigin == CORSOriginMirror && origin != "":
+		corsOrigin = origin
+
+	case a.AllowOrigin == CORSOriginMirror && origin == "":
+		corsOrigin = ""
+
+	case func() bool { _, ok := a.additionalOrigins[origin]; return ok }():
+		corsOrigin = origin
+	}
+
+	if preflight {
+		h.Set("Access-Control-Allow-Headers", strings.Join(a.AllowHeaders, ", "))
+		h.Set("Access-Control-Allow-Methods", strings.Join(a.AllowMethods, ", "))
+		h.Set("Access-Control-Max-Age", strconv.Itoa(a.MaxAge))
+	}
+
+	if corsOrigin != "" {
+		h.Set("Access-Control-Allow-Origin", corsOrigin)
+	}
+
+	h.Set("Access-Control-Expose-Headers", strings.Join(a.ExposeHeaders, ", "))
+
+	if a.AllowCredentials && corsOrigin != "*" && corsOrigin != "" {
+		h.Set("Access-Control-Allow-Credentials", "true")
+	}
+}

--- a/cors_test.go
+++ b/cors_test.go
@@ -10,7 +10,9 @@ import (
 func TestNewDefaultCORSAccessControlPolicy(t *testing.T) {
 
 	Convey("Calling NewDefaultCORSAccessControlPolicy should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", []string{"additionalorigin.com"})
+		c := NewDefaultCORSController("origin.com", []string{"additionalorigin.com"})
+		ac := c.PolicyForRequest(nil)
+
 		So(ac.AllowOrigin, ShouldEqual, "origin.com")
 		So(ac.additionalOrigins, ShouldResemble, map[string]struct{}{"additionalorigin.com": {}})
 		So(ac.AllowCredentials, ShouldBeTrue)
@@ -57,12 +59,14 @@ func TestNewDefaultCORSAccessControlPolicy(t *testing.T) {
 func TestCORSInject(t *testing.T) {
 
 	Convey("Calling inject with no http.Heade should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		a := NewDefaultCORSController("origin", nil)
+		ac := a.PolicyForRequest(nil)
 		So(func() { ac.Inject(nil, "", false) }, ShouldNotPanic)
 	})
 
 	Convey("Calling inject without passing request origin should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		a := NewDefaultCORSController("origin", nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -74,7 +78,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with request prefligh should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		a := NewDefaultCORSController("origin", nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "", true) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldNotBeEmpty)
@@ -86,7 +91,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with matching origin should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		a := NewDefaultCORSController("origin", nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "origin", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -98,7 +104,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with non matching origin should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		a := NewDefaultCORSController("origin", nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "notorigin", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -110,7 +117,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with matching additional origin should work", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("origin", []string{"additional.com"})
+		a := NewDefaultCORSController("origin", []string{"additional.com"})
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "additional.com", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -122,7 +130,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with * configured", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy("*", []string{"additional.com"})
+		a := NewDefaultCORSController("*", []string{"additional.com"})
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "additional.com", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -134,7 +143,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with mirroring configured and passed origin", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy(CORSOriginMirror, nil)
+		a := NewDefaultCORSController(CORSOriginMirror, nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "hello.com", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
@@ -146,7 +156,8 @@ func TestCORSInject(t *testing.T) {
 	})
 
 	Convey("Calling inject with mirroring configured and no passed origin", t, func() {
-		ac := NewDefaultCORSAccessControlPolicy(CORSOriginMirror, nil)
+		a := NewDefaultCORSController(CORSOriginMirror, nil)
+		ac := a.PolicyForRequest(nil)
 		h := http.Header{}
 		So(func() { ac.Inject(h, "", false) }, ShouldNotPanic)
 		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,159 @@
+package bahamut
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewDefaultCORSAccessControlPolicy(t *testing.T) {
+
+	Convey("Calling NewDefaultCORSAccessControlPolicy should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", []string{"additionalorigin.com"})
+		So(ac.AllowOrigin, ShouldEqual, "origin.com")
+		So(ac.additionalOrigins, ShouldResemble, map[string]struct{}{"additionalorigin.com": {}})
+		So(ac.AllowCredentials, ShouldBeTrue)
+		So(ac.MaxAge, ShouldEqual, 1500)
+		So(ac.AllowHeaders, ShouldResemble, []string{
+			"Authorization",
+			"Accept",
+			"Content-Type",
+			"Cache-Control",
+			"Cookie",
+			"If-Modified-Since",
+			"X-Requested-With",
+			"X-Count-Total",
+			"X-Namespace",
+			"X-External-Tracking-Type",
+			"X-External-Tracking-ID",
+			"X-TLS-Client-Certificate",
+			"Accept-Encoding",
+			"X-Fields",
+			"X-Read-Consistency",
+			"X-Write-Consistency",
+			"Idempotency-Key",
+		})
+		So(ac.AllowMethods, ShouldResemble, []string{
+			"GET",
+			"POST",
+			"PUT",
+			"DELETE",
+			"PATCH",
+			"HEAD",
+			"OPTIONS",
+		})
+		So(ac.ExposeHeaders, ShouldResemble, []string{
+			"X-Requested-With",
+			"X-Count-Total",
+			"X-Namespace",
+			"X-Messages",
+			"X-Fields",
+			"X-Next",
+		})
+	})
+}
+
+func TestCORSInject(t *testing.T) {
+
+	Convey("Calling inject with no http.Heade should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		So(func() { ac.Inject(nil, "", false) }, ShouldNotPanic)
+	})
+
+	Convey("Calling inject without passing request origin should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "origin")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with request prefligh should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "", true) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldEqual, "1500")
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "origin")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with matching origin should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "origin", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "origin")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with non matching origin should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "notorigin", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "origin")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with matching additional origin should work", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("origin", []string{"additional.com"})
+		h := http.Header{}
+		So(func() { ac.Inject(h, "additional.com", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "additional.com")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with * configured", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy("*", []string{"additional.com"})
+		h := http.Header{}
+		So(func() { ac.Inject(h, "additional.com", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "*")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "")
+	})
+
+	Convey("Calling inject with mirroring configured and passed origin", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy(CORSOriginMirror, nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "hello.com", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "hello.com")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
+	})
+
+	Convey("Calling inject with mirroring configured and no passed origin", t, func() {
+		ac := NewDefaultCORSAccessControlPolicy(CORSOriginMirror, nil)
+		h := http.Header{}
+		So(func() { ac.Inject(h, "", false) }, ShouldNotPanic)
+		So(h.Get("Access-Control-Allow-Headers"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Methods"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Max-Age"), ShouldBeEmpty)
+		So(h.Get("Access-Control-Allow-Origin"), ShouldEqual, "")
+		So(h.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+		So(h.Get("Access-Control-Allow-Credentials"), ShouldEqual, "")
+	})
+}

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -113,13 +113,12 @@ type gwconfig struct {
 	serverTLSConfig             *tls.Config
 	corsOrigin                  string
 	corsAllowCredentials        bool
-	additionalCorsOrigin        map[string]struct{}
+	additionalCorsOrigin        []string
 	trustForwardHeader          bool
 }
 
 func newGatewayConfig() *gwconfig {
 	return &gwconfig{
-		additionalCorsOrigin:        map[string]struct{}{},
 		corsOrigin:                  CORSOriginMirror,
 		corsAllowCredentials:        true,
 		prefixInterceptors:          map[string]InterceptorFunc{},
@@ -375,9 +374,7 @@ func OptionAllowedCORSOrigin(origin string) Option {
 // request Origin header as long as there is a match.
 func OptionAdditionnalAllowedCORSOrigin(origins []string) Option {
 	return func(cfg *gwconfig) {
-		for _, o := range origins {
-			cfg.additionalCorsOrigin[o] = struct{}{}
-		}
+		cfg.additionalCorsOrigin = origins
 	}
 }
 

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -60,12 +60,6 @@ const (
 	InterceptorActionStop
 )
 
-// CORSOriginMirror can be used with OptionAllowedCORSOrigin().
-// In this case, the gateway will mirror any upcoming ORIGIN header
-// in Access-Control-Allow-Origin response header.
-// NOTE: This should not be used in production.
-const CORSOriginMirror = "_mirror_"
-
 type gwconfig struct {
 	requestRewriter         RequestRewriter
 	responseRewriter        ResponseRewriter
@@ -119,7 +113,7 @@ type gwconfig struct {
 
 func newGatewayConfig() *gwconfig {
 	return &gwconfig{
-		corsOrigin:                  CORSOriginMirror,
+		corsOrigin:                  bahamut.CORSOriginMirror,
 		corsAllowCredentials:        true,
 		prefixInterceptors:          map[string]InterceptorFunc{},
 		suffixInterceptors:          map[string]InterceptorFunc{},

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -19,7 +19,7 @@ func Test_Options(t *testing.T) {
 		So(c.proxyProtocolEnabled, ShouldEqual, true)
 		So(c.proxyProtocolSubnet, ShouldEqual, "10.0.0.0/0")
 		So(c.corsAllowCredentials, ShouldEqual, true)
-		So(c.corsOrigin, ShouldEqual, CORSOriginMirror)
+		So(c.corsOrigin, ShouldEqual, bahamut.CORSOriginMirror)
 	})
 
 	Convey("Calling OptionTCPGobalRateLimiting should work", t, func() {

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -194,7 +194,7 @@ func Test_Options(t *testing.T) {
 	Convey("Calling OptionAdditionnalAllowedCORSOrigin should work", t, func() {
 		c := newGatewayConfig()
 		OptionAdditionnalAllowedCORSOrigin([]string{"dog"})(c)
-		So(c.additionalCorsOrigin, ShouldContainKey, "dog")
+		So(c.additionalCorsOrigin, ShouldResemble, []string{"dog"})
 	})
 
 	Convey("Calling OptionUpstreamURLScheme should work", t, func() {

--- a/gateway/utils.go
+++ b/gateway/utils.go
@@ -23,7 +23,8 @@ func injectGeneralHeader(h http.Header) http.Header {
 
 func injectCORSHeader(h http.Header, corsOrigin string, additionalCorsOrigin []string, allowCredentials bool, origin string, method string) http.Header {
 
-	ac := bahamut.NewDefaultCORSAccessControlPolicy(corsOrigin, additionalCorsOrigin)
+	a := bahamut.NewDefaultCORSController(corsOrigin, additionalCorsOrigin)
+	ac := a.PolicyForRequest(nil)
 	ac.AllowCredentials = allowCredentials
 	ac.Inject(h, origin, method == http.MethodOptions)
 	return h

--- a/gateway/utils_test.go
+++ b/gateway/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/bahamut"
 	"go.aporeto.io/tg/tglib"
 )
 
@@ -61,7 +62,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			"default",
 			args{
 				http.Header{},
-				CORSOriginMirror,
+				bahamut.CORSOriginMirror,
 				nil,
 				true,
 				"chien",
@@ -77,7 +78,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			"default OPTIONS",
 			args{
 				http.Header{},
-				CORSOriginMirror,
+				bahamut.CORSOriginMirror,
 				nil,
 				true,
 				"chien",
@@ -166,7 +167,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			"default empty origin",
 			args{
 				http.Header{},
-				CORSOriginMirror,
+				bahamut.CORSOriginMirror,
 				nil,
 				true,
 				"",
@@ -180,7 +181,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			"default empty OPTIONS",
 			args{
 				http.Header{},
-				CORSOriginMirror,
+				bahamut.CORSOriginMirror,
 				nil,
 				true,
 				"",

--- a/gateway/utils_test.go
+++ b/gateway/utils_test.go
@@ -47,7 +47,7 @@ func Test_injectCORSHeader(t *testing.T) {
 	type args struct {
 		h                    http.Header
 		corsOrigin           string
-		additionalCorsOrigin map[string]struct{}
+		additionalCorsOrigin []string
 		corsAllowCredentials bool
 		origin               string
 		method               string
@@ -62,7 +62,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				CORSOriginMirror,
-				map[string]struct{}{},
+				nil,
 				true,
 				"chien",
 				http.MethodGet,
@@ -78,7 +78,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				CORSOriginMirror,
-				map[string]struct{}{},
+				nil,
 				true,
 				"chien",
 				http.MethodOptions,
@@ -97,7 +97,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				"dog",
-				map[string]struct{}{},
+				nil,
 				true,
 				"chien",
 				http.MethodGet,
@@ -113,7 +113,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				"dog",
-				map[string]struct{}{},
+				nil,
 				true,
 				"chien",
 				http.MethodOptions,
@@ -132,7 +132,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				"dog",
-				map[string]struct{}{"chien": {}},
+				[]string{"chien"},
 				true,
 				"chien",
 				http.MethodGet,
@@ -148,7 +148,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				"dog",
-				map[string]struct{}{"chien": {}},
+				[]string{"chien"},
 				true,
 				"chien",
 				http.MethodOptions,
@@ -167,7 +167,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				CORSOriginMirror,
-				map[string]struct{}{},
+				nil,
 				true,
 				"",
 				http.MethodGet,
@@ -181,7 +181,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				CORSOriginMirror,
-				map[string]struct{}{},
+				nil,
 				true,
 				"",
 				http.MethodOptions,
@@ -199,7 +199,7 @@ func Test_injectCORSHeader(t *testing.T) {
 			args{
 				http.Header{},
 				"*",
-				map[string]struct{}{},
+				nil,
 				true,
 				"",
 				http.MethodOptions,
@@ -216,7 +216,7 @@ func Test_injectCORSHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := injectCORSHeader(tt.args.h, tt.args.corsOrigin, tt.args.additionalCorsOrigin, tt.args.corsAllowCredentials, tt.args.origin, tt.args.method); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("injectCORSHeader() = %v, want %v", got, tt.want)
+				t.Errorf("injectCORSHeader() = \ngot:  %v\nwant: %v", got, tt.want)
 			}
 		})
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -337,3 +337,12 @@ type PushSession interface {
 
 	DirectPush(...*elemental.Event)
 }
+
+// A CORSPolicyController allows to return
+// the CORS policy for a given http.Request.
+type CORSPolicyController interface {
+
+	// PolicyForRequest returns the CORSPolicy to
+	// apply for the given http.Request.
+	PolicyForRequest(*http.Request) *CORSPolicy
+}

--- a/options.go
+++ b/options.go
@@ -368,11 +368,11 @@ func OptAuditer(auditer Auditer) Option {
 // OptCORSAccessControl configures CORS access control policy.
 //
 // By default, no CORS headers are injected by bahamut.
-// You can use NewDefaultCORSAccessControlPolicy to get a sensible
+// You can use NewDefaultCORSAccessControler to get a sensible
 // default policy.
-func OptCORSAccessControl(ac *CORSAccessControlPolicy) Option {
+func OptCORSAccessControl(controller CORSPolicyController) Option {
 	return func(c *config) {
-		c.security.accessControl = ac
+		c.security.corsController = controller
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -365,6 +365,17 @@ func OptAuditer(auditer Auditer) Option {
 	}
 }
 
+// OptCORSAccessControl configures CORS access control policy.
+//
+// By default, no CORS headers are injected by bahamut.
+// You can use NewDefaultCORSAccessControlPolicy to get a sensible
+// default policy.
+func OptCORSAccessControl(ac *CORSAccessControlPolicy) Option {
+	return func(c *config) {
+		c.security.accessControl = ac
+	}
+}
+
 // OptRateLimiting configures the global rate limiting.
 func OptRateLimiting(limit float64, burst int) Option {
 	return func(c *config) {

--- a/options_test.go
+++ b/options_test.go
@@ -212,9 +212,9 @@ func TestBahamut_Options(t *testing.T) {
 	})
 
 	Convey("Calling OptAuditer should work", t, func() {
-		a := &CORSAccessControlPolicy{}
+		a := NewDefaultCORSController("", nil)
 		OptCORSAccessControl(a)(&c)
-		So(c.security.accessControl, ShouldEqual, a)
+		So(c.security.corsController, ShouldEqual, a)
 	})
 
 	Convey("Calling OptRateLimiting should work", t, func() {

--- a/options_test.go
+++ b/options_test.go
@@ -211,6 +211,12 @@ func TestBahamut_Options(t *testing.T) {
 		So(c.security.auditer, ShouldEqual, a)
 	})
 
+	Convey("Calling OptAuditer should work", t, func() {
+		a := &CORSAccessControlPolicy{}
+		OptCORSAccessControl(a)(&c)
+		So(c.security.accessControl, ShouldEqual, a)
+	})
+
 	Convey("Calling OptRateLimiting should work", t, func() {
 		rlm := rate.NewLimiter(rate.Limit(10), 20)
 		OptRateLimiting(10, 20)(&c)

--- a/rest_server.go
+++ b/rest_server.go
@@ -197,6 +197,12 @@ func (a *restServer) installRoutes(routesInfo map[int][]RouteInfo) {
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:category"), a.makeHandler(handleInfo))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleInfo))
 
+	if a.cfg.security.accessControl != nil {
+		a.multiplexer.Options("*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			setCommonHeader(w, elemental.EncodingTypeJSON)
+			a.cfg.security.accessControl.Inject(w.Header(), r.Header.Get("origin"), true)
+		}))
+	}
 }
 
 func (a *restServer) start(ctx context.Context, routesInfo map[int][]RouteInfo) {

--- a/rest_server_helpers.go
+++ b/rest_server_helpers.go
@@ -37,8 +37,14 @@ func setCommonHeader(w http.ResponseWriter, encoding elemental.EncodingType) {
 	}
 }
 
-func makeNotFoundHandler(accessControl *CORSAccessControlPolicy) func(w http.ResponseWriter, r *http.Request) {
+func makeNotFoundHandler(controller CORSPolicyController) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		var corsPolicy *CORSPolicy
+		if controller != nil {
+			corsPolicy = controller.PolicyForRequest(r)
+		}
+
 		writeHTTPResponse(
 			w,
 			makeErrorResponse(
@@ -49,13 +55,13 @@ func makeNotFoundHandler(accessControl *CORSAccessControlPolicy) func(w http.Res
 				nil,
 			),
 			r.Header.Get("origin"),
-			accessControl,
+			corsPolicy,
 		)
 	}
 }
 
 // writeHTTPResponse writes the response into the given http.ResponseWriter.
-func writeHTTPResponse(w http.ResponseWriter, r *elemental.Response, origin string, accessControl *CORSAccessControlPolicy) int {
+func writeHTTPResponse(w http.ResponseWriter, r *elemental.Response, origin string, accessControl *CORSPolicy) int {
 
 	// If r is nil, we simply stop.
 	// It mostly means the client closed the connection and

--- a/rest_server_helpers_test.go
+++ b/rest_server_helpers_test.go
@@ -57,11 +57,9 @@ func TestRestServerHelper_notFoundHandler(t *testing.T) {
 		h.Add("Origin", "toto")
 
 		w := httptest.NewRecorder()
-		makeNotFoundHandler()(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
+		makeNotFoundHandler(nil)(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
 
-		Convey("Then the response should be correct", func() {
-			So(w.Code, ShouldEqual, http.StatusNotFound)
-		})
+		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
 }
 
@@ -70,136 +68,100 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 	Convey("Given I have a response with a nil response", t, func() {
 
 		w := httptest.NewRecorder()
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 
-		Convey("When I call writeHTTPResponse", func() {
+		w.Code = 200
+		code := writeHTTPResponse(w, nil, "", ac)
 
-			w.Code = 200
-			code := writeHTTPResponse(w, nil)
-
-			Convey("Then the code should be 200", func() {
-				So(code, ShouldEqual, 0)
-			})
-		})
+		So(code, ShouldEqual, 0)
 	})
 
 	Convey("Given I have a response with a redirect", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 		r.Redirect = "https://la.bas"
 
-		Convey("When I call writeHTTPResponse", func() {
+		code := writeHTTPResponse(w, r, "", ac)
 
-			code := writeHTTPResponse(w, r)
-
-			Convey("Then the should header Location should be set", func() {
-				So(w.Header().Get("location"), ShouldEqual, "https://la.bas")
-			})
-
-			Convey("Then the code should be 302", func() {
-				So(code, ShouldEqual, 302)
-			})
-		})
+		So(w.Header().Get("location"), ShouldEqual, "https://la.bas")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
+		So(code, ShouldEqual, 302)
 	})
 
 	Convey("Given I have a response with no data", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 
 		r.StatusCode = http.StatusNoContent
 
-		Convey("When I call writeHTTPResponse", func() {
+		code := writeHTTPResponse(w, r, "", ac)
 
-			code := writeHTTPResponse(w, r)
-
-			Convey("Then the should headers should be correct", func() {
-				So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")
-				So(w.Header().Get("X-Messages"), ShouldEqual, "")
-			})
-
-			Convey("Then the code should correct", func() {
-				So(w.Code, ShouldEqual, http.StatusNoContent)
-			})
-
-			Convey("Then the code should be http.StatusNoContent", func() {
-				So(code, ShouldEqual, http.StatusNoContent)
-			})
-		})
+		So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")
+		So(w.Header().Get("X-Messages"), ShouldEqual, "")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+		So(code, ShouldEqual, http.StatusNoContent)
 	})
 
 	Convey("Given I have a response messages", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 
 		r.Messages = []string{"msg1", "msg2"}
 		r.StatusCode = 200
 
-		Convey("When I call writeHTTPResponse", func() {
+		code := writeHTTPResponse(w, r, "", ac)
 
-			code := writeHTTPResponse(w, r)
-
-			Convey("Then the should header message should be set", func() {
-				So(w.Header().Get("X-Messages"), ShouldEqual, "msg1;msg2")
-			})
-
-			Convey("Then the code should be http.StatusNoContent", func() {
-				So(code, ShouldEqual, http.StatusOK)
-			})
-		})
+		So(w.Header().Get("X-Messages"), ShouldEqual, "msg1;msg2")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
+		So(code, ShouldEqual, http.StatusOK)
 	})
 
 	Convey("Given I have a response next", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 
 		r.Next = "next"
 		r.StatusCode = 200
 
-		Convey("When I call writeHTTPResponse", func() {
+		code := writeHTTPResponse(w, r, "", ac)
 
-			code := writeHTTPResponse(w, r)
-
-			Convey("Then the should header message should be set", func() {
-				So(w.Header().Get("X-Next"), ShouldEqual, "next")
-			})
-
-			Convey("Then the code should be http.StatusNoContent", func() {
-				So(code, ShouldEqual, http.StatusOK)
-			})
-		})
+		So(w.Header().Get("X-Next"), ShouldEqual, "next")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
+		So(code, ShouldEqual, http.StatusOK)
 	})
 
 	Convey("Given I have a response with data", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 
 		r.StatusCode = http.StatusOK
 		r.Data = []byte("hello")
 
-		Convey("When I call writeHTTPResponse", func() {
+		code := writeHTTPResponse(w, r, "", ac)
 
-			code := writeHTTPResponse(w, r)
-
-			Convey("Then the body should be correct", func() {
-				So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")
-				So(w.Header().Get("X-Messages"), ShouldEqual, "")
-				So(w.Body.String(), ShouldEqual, string(r.Data))
-			})
-
-			Convey("Then the code should be http.StatusNoContent", func() {
-				So(code, ShouldEqual, http.StatusOK)
-			})
-		})
+		So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")
+		So(w.Header().Get("X-Messages"), ShouldEqual, "")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
+		So(w.Body.String(), ShouldEqual, string(r.Data))
+		So(code, ShouldEqual, http.StatusOK)
 	})
 
 	Convey("Given I have a some cookies", t, func() {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
+		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
 		r.StatusCode = 200
 		r.Cookies = []*http.Cookie{
 			{
@@ -212,14 +174,10 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 			},
 		}
 
-		Convey("When I call writeHTTPResponse", func() {
+		writeHTTPResponse(w, r, "", ac)
 
-			writeHTTPResponse(w, r)
-
-			Convey("Then the should header message should be set", func() {
-				So(w.Header()["Set-Cookie"], ShouldResemble, []string{"ca=ca", "cb=cb"})
-			})
-		})
+		So(w.Header()["Set-Cookie"], ShouldResemble, []string{"ca=ca", "cb=cb"})
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "origin.com")
 	})
 }
 

--- a/rest_server_helpers_test.go
+++ b/rest_server_helpers_test.go
@@ -68,7 +68,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 	Convey("Given I have a response with a nil response", t, func() {
 
 		w := httptest.NewRecorder()
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 
 		w.Code = 200
 		code := writeHTTPResponse(w, nil, "", ac)
@@ -80,7 +81,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 		r.Redirect = "https://la.bas"
 
 		code := writeHTTPResponse(w, r, "", ac)
@@ -94,7 +96,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 
 		r.StatusCode = http.StatusNoContent
 
@@ -111,7 +114,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 
 		r.Messages = []string{"msg1", "msg2"}
 		r.StatusCode = 200
@@ -127,7 +131,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 
 		r.Next = "next"
 		r.StatusCode = 200
@@ -143,7 +148,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 
 		r.StatusCode = http.StatusOK
 		r.Data = []byte("hello")
@@ -161,7 +167,8 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := elemental.NewResponse(elemental.NewRequest())
-		ac := NewDefaultCORSAccessControlPolicy("origin.com", nil)
+		a := NewDefaultCORSController("origin.com", nil)
+		ac := a.PolicyForRequest(nil)
 		r.StatusCode = 200
 		r.Cookies = []*http.Cookie{
 			{

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -217,6 +217,11 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	r = r.WithContext(n.mainContext)
 
+	var corsPolicy *CORSPolicy
+	if controller := n.cfg.security.corsController; controller != nil {
+		corsPolicy = controller.PolicyForRequest(r)
+	}
+
 	readEncodingType, writeEncodingType, err := elemental.EncodingFromHeaders(r.Header)
 	if err != nil {
 		writeHTTPResponse(
@@ -229,7 +234,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 				nil,
 			),
 			r.Header.Get("origin"),
-			n.cfg.security.accessControl,
+			corsPolicy,
 		)
 	}
 
@@ -258,7 +263,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 				nil,
 			),
 			r.Header.Get("origin"),
-			n.cfg.security.accessControl,
+			corsPolicy,
 		)
 		return
 	}
@@ -274,7 +279,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 				nil,
 			),
 			r.Header.Get("origin"),
-			n.cfg.security.accessControl,
+			corsPolicy,
 		)
 		return
 	}
@@ -291,7 +296,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 				nil,
 			),
 			r.Header.Get("origin"),
-			n.cfg.security.accessControl,
+			corsPolicy,
 		)
 		return
 	}
@@ -308,7 +313,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 				nil,
 			),
 			r.Header.Get("origin"),
-			n.cfg.security.accessControl,
+			corsPolicy,
 		)
 		return
 	}

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -219,7 +219,18 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	readEncodingType, writeEncodingType, err := elemental.EncodingFromHeaders(r.Header)
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil, nil))
+		writeHTTPResponse(
+			w,
+			makeErrorResponse(
+				r.Context(),
+				elemental.NewResponse(elemental.NewRequest()),
+				err,
+				nil,
+				nil,
+			),
+			r.Header.Get("origin"),
+			n.cfg.security.accessControl,
+		)
 	}
 
 	session := newWSPushSession(r, n.cfg, n.unregisterSession, readEncodingType, writeEncodingType)
@@ -237,24 +248,68 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	session.cookies = r.Cookies()
 
 	if err := n.authSession(session); err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil, nil))
+		writeHTTPResponse(
+			w,
+			makeErrorResponse(
+				r.Context(),
+				elemental.NewResponse(elemental.NewRequest()),
+				err,
+				nil,
+				nil,
+			),
+			r.Header.Get("origin"),
+			n.cfg.security.accessControl,
+		)
 		return
 	}
 
 	if err := n.initPushSession(session); err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil, nil))
+		writeHTTPResponse(
+			w,
+			makeErrorResponse(
+				r.Context(),
+				elemental.NewResponse(elemental.NewRequest()),
+				err,
+				nil,
+				nil,
+			),
+			r.Header.Get("origin"),
+			n.cfg.security.accessControl,
+		)
 		return
 	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil, nil))
+		writeHTTPResponse(
+			w,
+			makeErrorResponse(
+				r.Context(),
+				elemental.NewResponse(elemental.NewRequest()),
+				err,
+				nil,
+				nil,
+			),
+			r.Header.Get("origin"),
+			n.cfg.security.accessControl,
+		)
 		return
 	}
 
 	conn, err := wsc.Accept(r.Context(), ws, wsc.Config{WriteChanSize: 64, ReadChanSize: 16})
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil, nil))
+		writeHTTPResponse(
+			w,
+			makeErrorResponse(
+				r.Context(),
+				elemental.NewResponse(elemental.NewRequest()),
+				err,
+				nil,
+				nil,
+			),
+			r.Header.Get("origin"),
+			n.cfg.security.accessControl,
+		)
 		return
 	}
 


### PR DESCRIPTION
This patch adds a new option `OptCORSAccessControlPolicy` to set a custom CORS policy. It can be used in a standalone bahamut service, and not only the gateway