### PR TITLE
new/options: added option to set tls.Config.VerifyPeerCertificates

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,6 +102,7 @@ type config struct {
 		authType                        tls.ClientAuthType
 		serverCertificates              []tls.Certificate
 		serverCertificatesRetrieverFunc func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+		peerCertificateVerifyFunc       func([][]byte, [][]*x509.Certificate) error
 		disableSessionTicket            bool
 		nextProtos                      []string
 	}

--- a/options.go
+++ b/options.go
@@ -317,6 +317,14 @@ func OptMTLS(caPool *x509.CertPool, authType tls.ClientAuthType) Option {
 	}
 }
 
+// OptMTLSVerifyPeerCertificate configures the optionnal function to
+// to perform custom peer certificate verification.
+func OptMTLSVerifyPeerCertificate(f func([][]byte, [][]*x509.Certificate) error) Option {
+	return func(c *config) {
+		c.tls.peerCertificateVerifyFunc = f
+	}
+}
+
 // OptTLSDisableSessionTicket controls if the TLS session tickets should
 // be disabled.
 func OptTLSDisableSessionTicket(disabled bool) Option {

--- a/options.go
+++ b/options.go
@@ -317,9 +317,9 @@ func OptMTLS(caPool *x509.CertPool, authType tls.ClientAuthType) Option {
 	}
 }
 
-// OptMTLSVerifyPeerCertificate configures the optionnal function to
+// OptMTLSVerifyPeerCertificates configures the optionnal function to
 // to perform custom peer certificate verification.
-func OptMTLSVerifyPeerCertificate(f func([][]byte, [][]*x509.Certificate) error) Option {
+func OptMTLSVerifyPeerCertificates(f func([][]byte, [][]*x509.Certificate) error) Option {
 	return func(c *config) {
 		c.tls.peerCertificateVerifyFunc = f
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -188,7 +188,7 @@ func TestBahamut_Options(t *testing.T) {
 
 	Convey("Calling OptMTLSPeer", t, func() {
 		f := func([][]byte, [][]*x509.Certificate) error { return nil }
-		OptMTLSVerifyPeerCertificate(f)(&c)
+		OptMTLSVerifyPeerCertificates(f)(&c)
 		So(c.tls.peerCertificateVerifyFunc, ShouldEqual, f)
 	})
 

--- a/options_test.go
+++ b/options_test.go
@@ -186,6 +186,12 @@ func TestBahamut_Options(t *testing.T) {
 		So(c.tls.authType, ShouldEqual, authType)
 	})
 
+	Convey("Calling OptMTLSPeer", t, func() {
+		f := func([][]byte, [][]*x509.Certificate) error { return nil }
+		OptMTLSVerifyPeerCertificate(f)(&c)
+		So(c.tls.peerCertificateVerifyFunc, ShouldEqual, f)
+	})
+
 	Convey("Calling OptTLSDisableSessionTicket should work", t, func() {
 		OptTLSDisableSessionTicket(true)(&c)
 		So(c.tls.disableSessionTicket, ShouldEqual, true)

--- a/rest_server.go
+++ b/rest_server.go
@@ -75,6 +75,7 @@ func (a *restServer) createSecureHTTPServer(address string) *http.Server {
 		PreferServerCipherSuites: true,
 		NextProtos:               a.cfg.tls.nextProtos,
 		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		VerifyPeerCertificate:    a.cfg.tls.peerCertificateVerifyFunc,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,


### PR DESCRIPTION
Adds option `OptMTLSVerifyPeerCertificates' to allow configuring a custom client certificate verification function.