### PR TITLE
gateway/sourceextractor: add way to consider cookie.

### DIFF
--- a/gateway/extractors.go
+++ b/gateway/extractors.go
@@ -7,16 +7,44 @@ import (
 	"github.com/cespare/xxhash"
 )
 
-type defaultSourceExtractor struct{}
+type defaultSourceExtractor struct {
+	authCookieName string
+}
+
+// NewDefaultSourceExtractor returns a default SourceExtractor.
+// A source extractor will discriminate the source of a request
+// based on a hash of its authentication string.
+// It will first use an eventual cookie with the given name,
+// then use then use the Authorization header.
+// If both are empty, the bucket key will be 'default'.
+// If authCookieName is empty, only the value of the Authorization
+// header will be taken into account.
+func NewDefaultSourceExtractor(authCookieName string) SourceExtractor {
+	return defaultSourceExtractor{
+		authCookieName: authCookieName,
+	}
+}
 
 func (f defaultSourceExtractor) ExtractSource(r *http.Request) (string, error) {
 
+	var v string
 	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
+
+	var authCookie *http.Cookie
+	if f.authCookieName != "" {
+		authCookie, _ = r.Cookie(f.authCookieName)
+	}
+
+	switch {
+	case authCookie != nil && authCookie.Value != "":
+		v = authCookie.Value
+	case authHeader != "":
+		v = authHeader
+	default:
 		return "default", nil
 	}
 
-	return fmt.Sprintf("%d", xxhash.Sum64([]byte(authHeader))), nil
+	return fmt.Sprintf("%d", xxhash.Sum64([]byte(v))), nil
 }
 
 type defaultTCPSourceExtractor struct{}

--- a/gateway/extractors_test.go
+++ b/gateway/extractors_test.go
@@ -18,7 +18,7 @@ func Test_defaultSourceExtractor_ExtractSource(t *testing.T) {
 	}{
 		{
 			"no header",
-			defaultSourceExtractor{},
+			NewDefaultSourceExtractor("").(defaultSourceExtractor),
 			args{
 				&http.Request{Header: http.Header{}},
 			},
@@ -27,9 +27,74 @@ func Test_defaultSourceExtractor_ExtractSource(t *testing.T) {
 		},
 		{
 			"header",
-			defaultSourceExtractor{},
+			NewDefaultSourceExtractor("").(defaultSourceExtractor),
 			args{
 				&http.Request{Header: http.Header{"Authorization": {"Bearer X"}}},
+			},
+			"763578776710062675",
+			false,
+		},
+		{
+			"cookie",
+			NewDefaultSourceExtractor("X-Token").(defaultSourceExtractor),
+			args{
+				func() *http.Request {
+					r := &http.Request{Header: http.Header{}}
+					r.AddCookie(&http.Cookie{Name: "X-Token", Value: "X"})
+					return r
+				}(),
+			},
+			"15784302077936868069",
+			false,
+		},
+		{
+			"cookie with no configured authCookieName",
+			NewDefaultSourceExtractor("").(defaultSourceExtractor),
+			args{
+				func() *http.Request {
+					r := &http.Request{Header: http.Header{}}
+					r.AddCookie(&http.Cookie{Name: "X-Token", Value: "X"})
+					return r
+				}(),
+			},
+			"default",
+			false,
+		},
+		{
+			"empty cookie",
+			NewDefaultSourceExtractor("X-Token").(defaultSourceExtractor),
+			args{
+				func() *http.Request {
+					r := &http.Request{Header: http.Header{}}
+					r.AddCookie(&http.Cookie{})
+					return r
+				}(),
+			},
+			"default",
+			false,
+		},
+		{
+			"cookie and header (cookie should have prio)",
+			NewDefaultSourceExtractor("X-Token").(defaultSourceExtractor),
+			args{
+				func() *http.Request {
+					r := &http.Request{Header: http.Header{"Authorization": {"Bearer X"}}}
+					r.AddCookie(&http.Cookie{Name: "X-Token", Value: "X"})
+					return r
+				}(),
+			},
+			"15784302077936868069",
+			false,
+		},
+		{
+			"empty cookie and header (header should fall back)",
+			NewDefaultSourceExtractor("X-Token").(defaultSourceExtractor),
+			args{
+				func() *http.Request {
+					r := &http.Request{Header: http.Header{"Authorization": {"Bearer X"}}}
+					r.AddCookie(&http.Cookie{})
+					return r
+				}(),
 			},
 			"763578776710062675",
 			false,
@@ -37,7 +102,7 @@ func Test_defaultSourceExtractor_ExtractSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := defaultSourceExtractor{}
+			f := tt.f
 			got, err := f.ExtractSource(tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("defaultSourceExtractor.ExtractSource() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This patch adds a new function NewDefaultSourceExtractor(string) that
returns a SourceExtractor that can also look for a cookie with the given
name to discriminate the source of a request.
