### PR TITLE
new: support for api prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ lint:
 	golangci-lint run \
 		--disable-all \
 		--exclude-use-default=false \
+		--exclude=package-comments \
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \
@@ -25,7 +26,6 @@ lint:
 		--enable=nakedret \
 		--enable=typecheck \
 		./...
-
 test:
 	go test ./... -race -cover -covermode=atomic -coverprofile=unit_coverage.cov
 

--- a/gateway/upstreamer/push/notifier.go
+++ b/gateway/upstreamer/push/notifier.go
@@ -19,6 +19,7 @@ type Notifier struct {
 	serviceStatusTopic string
 	limiters           IdentityToAPILimitersRegistry
 	frequency          time.Duration
+	prefix             string
 }
 
 // NewNotifier returns a new Wutai notifier.
@@ -42,6 +43,7 @@ func NewNotifier(
 		serviceStatusTopic: serviceStatusTopic,
 		limiters:           cfg.rateLimits,
 		frequency:          cfg.pingInterval,
+		prefix:             cfg.prefix,
 	}
 }
 
@@ -57,6 +59,7 @@ func (w *Notifier) MakeStartHook(ctx context.Context) func(server bahamut.Server
 
 		sp := servicePing{
 			Name:         w.serviceName,
+			Prefix:       w.prefix,
 			Status:       entityStatusHello,
 			Endpoint:     w.endpoint,
 			Routes:       server.RoutesInfo(),
@@ -122,6 +125,7 @@ func (w *Notifier) MakeStopHook() func(server bahamut.Server) error {
 		pub := bahamut.NewPublication(w.serviceStatusTopic)
 		if err := pub.Encode(servicePing{
 			Name:     w.serviceName,
+			Prefix:   w.prefix,
 			Status:   entityStatusGoodbye,
 			Endpoint: w.endpoint,
 		}); err != nil {

--- a/gateway/upstreamer/push/notifier_options.go
+++ b/gateway/upstreamer/push/notifier_options.go
@@ -55,7 +55,7 @@ func OptionNotifierPrefix(prefix string) NotifierOption {
 	}
 }
 
-// OptionNotiferPrivateAPIOverrides allows to pass a map of identity to boolean
+// OptionNotifierPrivateAPIOverrides allows to pass a map of identity to boolean
 // that will be used to override the specificaton's "private" flag. This allows
 // the service to force a public API to be private (or vice versa).
 //

--- a/gateway/upstreamer/push/notifier_options.go
+++ b/gateway/upstreamer/push/notifier_options.go
@@ -1,17 +1,23 @@
 package push
 
-import "time"
+import (
+	"time"
+
+	"go.aporeto.io/elemental"
+)
 
 type notifierConfig struct {
-	rateLimits   IdentityToAPILimitersRegistry
-	pingInterval time.Duration
-	prefix       string
+	rateLimits       IdentityToAPILimitersRegistry
+	pingInterval     time.Duration
+	prefix           string
+	privateOverrides map[string]bool
 }
 
 func newNotifierConfig() notifierConfig {
 	return notifierConfig{
-		rateLimits:   IdentityToAPILimitersRegistry{},
-		pingInterval: 5 * time.Second,
+		rateLimits:       IdentityToAPILimitersRegistry{},
+		pingInterval:     5 * time.Second,
+		privateOverrides: map[string]bool{},
 	}
 }
 
@@ -46,5 +52,20 @@ func OptionNotifierAnnounceRateLimits(rls IdentityToAPILimitersRegistry) Notifie
 func OptionNotifierPrefix(prefix string) NotifierOption {
 	return func(c *notifierConfig) {
 		c.prefix = prefix
+	}
+}
+
+// OptionNotiferPrivateAPIOverrides allows to pass a map of identity to boolean
+// that will be used to override the specificaton's "private" flag. This allows
+// the service to force a public API to be private (or vice versa).
+//
+// NOTE: this does not change the internal data in bahamut's server RouteInfo.
+// As far as bahamut server is concerned, the route Private flag did not
+// change. This is only affecting the gateway.
+func OptionNotifierPrivateAPIOverrides(overrides map[elemental.Identity]bool) NotifierOption {
+	return func(c *notifierConfig) {
+		for k, v := range overrides {
+			c.privateOverrides[k.Category] = v
+		}
 	}
 }

--- a/gateway/upstreamer/push/notifier_options.go
+++ b/gateway/upstreamer/push/notifier_options.go
@@ -5,6 +5,7 @@ import "time"
 type notifierConfig struct {
 	rateLimits   IdentityToAPILimitersRegistry
 	pingInterval time.Duration
+	prefix       string
 }
 
 func newNotifierConfig() notifierConfig {
@@ -37,5 +38,13 @@ func OptionNotifierAnnounceRateLimits(rls IdentityToAPILimitersRegistry) Notifie
 		for k, v := range rls {
 			c.rateLimits[k] = v
 		}
+	}
+}
+
+// OptionNotifierPrefix sets the API prefix that the gateway should
+// add to the API routes for that service.
+func OptionNotifierPrefix(prefix string) NotifierOption {
+	return func(c *notifierConfig) {
+		c.prefix = prefix
 	}
 }

--- a/gateway/upstreamer/push/notifier_options_test.go
+++ b/gateway/upstreamer/push/notifier_options_test.go
@@ -37,7 +37,6 @@ func Test_NotiferOptions(t *testing.T) {
 			elemental.MakeIdentity("thing", "things"): true,
 		}
 		OptionNotifierPrivateAPIOverrides(ov)(&c)
-		So(c.privateOverrides, ShouldResemble, ov)
-		So(c.privateOverrides, ShouldNotEqual, ov)
+		So(c.privateOverrides, ShouldResemble, map[string]bool{"things": true})
 	})
 }

--- a/gateway/upstreamer/push/notifier_options_test.go
+++ b/gateway/upstreamer/push/notifier_options_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/elemental"
 	"golang.org/x/time/rate"
 )
 
@@ -29,5 +30,14 @@ func Test_NotiferOptions(t *testing.T) {
 	Convey("Calling OptionNotifierPrefix should work", t, func() {
 		OptionNotifierPrefix("prefix")(&c)
 		So(c.prefix, ShouldEqual, "prefix")
+	})
+
+	Convey("Calling OptionNotifierAPIPrivateOverrides should work", t, func() {
+		ov := map[elemental.Identity]bool{
+			elemental.MakeIdentity("thing", "things"): true,
+		}
+		OptionNotifierPrivateAPIOverrides(ov)(&c)
+		So(c.privateOverrides, ShouldResemble, ov)
+		So(c.privateOverrides, ShouldNotEqual, ov)
 	})
 }

--- a/gateway/upstreamer/push/notifier_options_test.go
+++ b/gateway/upstreamer/push/notifier_options_test.go
@@ -26,4 +26,8 @@ func Test_NotiferOptions(t *testing.T) {
 		So(c.pingInterval, ShouldEqual, 3*time.Hour)
 	})
 
+	Convey("Calling OptionNotifierPrefix should work", t, func() {
+		OptionNotifierPrefix("prefix")(&c)
+		So(c.prefix, ShouldEqual, "prefix")
+	})
 }

--- a/gateway/upstreamer/push/notifier_test.go
+++ b/gateway/upstreamer/push/notifier_test.go
@@ -11,7 +11,7 @@ import (
 	testmodel "go.aporeto.io/elemental/test/model"
 )
 
-func TestNotifier(t *testing.T) {
+func TestNonNotifier(t *testing.T) {
 
 	Convey("Given I have a pubsub client and a bahamut server", t, func() {
 
@@ -52,7 +52,7 @@ func TestNotifier(t *testing.T) {
 				So(n.serviceStatusTopic, ShouldEqual, "topic")
 				So(n.endpoint, ShouldEqual, "1.1.1.1:1")
 				So(n.limiters, ShouldResemble, limiters)
-				So(n.limiters, ShouldNotEqual, limiters)
+				So(n.prefix, ShouldEqual, "")
 			})
 
 			Convey("When I call MakeStartHook and call the hook", func() {
@@ -83,9 +83,11 @@ func TestNotifier(t *testing.T) {
 						panic(err)
 					}
 
+					So(sping.Key(), ShouldEqual, "srv1")
 					So(sping.Name, ShouldEqual, "srv1")
 					So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
 					So(sping.Status, ShouldEqual, entityStatusHello)
+					So(sping.Prefix, ShouldEqual, "")
 
 					Convey("Then I wait 1.5sec and I should get another pusb", func() {
 
@@ -100,9 +102,11 @@ func TestNotifier(t *testing.T) {
 							panic(err)
 						}
 
+						So(sping.Key(), ShouldEqual, "srv1")
 						So(sping.Name, ShouldEqual, "srv1")
 						So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
 						So(sping.Status, ShouldEqual, entityStatusHello)
+						So(sping.Prefix, ShouldEqual, "")
 					})
 				})
 			})
@@ -132,9 +136,147 @@ func TestNotifier(t *testing.T) {
 						panic(err)
 					}
 
+					So(sping.Key(), ShouldEqual, "srv1")
 					So(sping.Name, ShouldEqual, "srv1")
 					So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
 					So(sping.Status, ShouldEqual, entityStatusGoodbye)
+					So(sping.Prefix, ShouldEqual, "")
+				})
+			})
+		})
+	})
+}
+func TestPrefixedNotifier(t *testing.T) {
+
+	Convey("Given I have a pubsub client and a bahamut server", t, func() {
+
+		server := bahamut.New(
+			bahamut.OptModel(
+				map[int]elemental.ModelManager{
+					0: testmodel.Manager(),
+				},
+			),
+		)
+
+		pubsub := bahamut.NewLocalPubSubClient()
+		if err := pubsub.Connect(context.Background()); err != nil {
+			panic(err)
+		}
+
+		errCh := make(chan error, 10)
+		pubCh := make(chan *bahamut.Publication, 10)
+		defer pubsub.Subscribe(pubCh, errCh, "topic")()
+
+		Convey("When I call NewNotifier", func() {
+
+			limiters := IdentityToAPILimitersRegistry{}
+
+			n := NewNotifier(
+				pubsub,
+				"topic",
+				"srv1",
+				"1.1.1.1:1",
+				OptionNotifierAnnounceRateLimits(limiters),
+				OptionNotifierPingInterval(time.Second),
+				OptionNotifierPrefix("prefix"),
+			)
+
+			Convey("Then n should be correct", func() {
+				So(n, ShouldNotBeNil)
+				So(n.pubsub, ShouldEqual, pubsub)
+				So(n.serviceName, ShouldEqual, "srv1")
+				So(n.serviceStatusTopic, ShouldEqual, "topic")
+				So(n.endpoint, ShouldEqual, "1.1.1.1:1")
+				So(n.limiters, ShouldResemble, limiters)
+				So(n.prefix, ShouldEqual, "prefix")
+			})
+
+			Convey("When I call MakeStartHook and call the hook", func() {
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				hook := n.MakeStartHook(ctx)
+
+				err := hook(server)
+
+				Convey("Then err should be nil", func() {
+					So(err, ShouldBeNil)
+				})
+
+				var p *bahamut.Publication
+				select {
+				case <-time.After(300 * time.Millisecond):
+				case p = <-pubCh:
+				}
+
+				Convey("Then the pubsub should have received a push", func() {
+
+					So(p, ShouldNotBeNil)
+
+					sping := &servicePing{}
+					if err := p.Decode(sping); err != nil {
+						panic(err)
+					}
+
+					So(sping.Key(), ShouldEqual, "prefix/srv1")
+					So(sping.Name, ShouldEqual, "srv1")
+					So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
+					So(sping.Status, ShouldEqual, entityStatusHello)
+					So(sping.Prefix, ShouldEqual, "prefix")
+
+					Convey("Then I wait 1.5sec and I should get another pusb", func() {
+
+						var p *bahamut.Publication
+						select {
+						case p = <-pubCh:
+						case <-time.After(1500 * time.Millisecond):
+						}
+
+						sping := &servicePing{}
+						if err := p.Decode(sping); err != nil {
+							panic(err)
+						}
+
+						So(sping.Key(), ShouldEqual, "prefix/srv1")
+						So(sping.Name, ShouldEqual, "srv1")
+						So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
+						So(sping.Status, ShouldEqual, entityStatusHello)
+						So(sping.Prefix, ShouldEqual, "prefix")
+					})
+				})
+			})
+
+			Convey("When I call MakeStopHook and call the hook", func() {
+
+				hook := n.MakeStopHook()
+
+				err := hook(server)
+
+				Convey("Then err should be nil", func() {
+					So(err, ShouldBeNil)
+				})
+
+				var p *bahamut.Publication
+				select {
+				case <-time.After(300 * time.Millisecond):
+				case p = <-pubCh:
+				}
+
+				Convey("Then the pubsub should have received a push", func() {
+
+					So(p, ShouldNotBeNil)
+
+					sping := &servicePing{}
+					if err := p.Decode(sping); err != nil {
+						panic(err)
+					}
+
+					So(sping.Key(), ShouldEqual, "prefix/srv1")
+					So(sping.Name, ShouldEqual, "srv1")
+					So(sping.Endpoint, ShouldEqual, "1.1.1.1:1")
+					So(sping.Status, ShouldEqual, entityStatusGoodbye)
+					So(sping.Prefix, ShouldEqual, "prefix")
 				})
 			})
 		})

--- a/gateway/upstreamer/push/notifier_test.go
+++ b/gateway/upstreamer/push/notifier_test.go
@@ -23,8 +23,8 @@ func TestNonNotifier(t *testing.T) {
 			),
 		)
 
-		server.RegisterProcessor(struct{}{}, testmodel.ListIdentity)
-		server.RegisterProcessor(struct{}{}, testmodel.TaskIdentity)
+		_ = server.RegisterProcessor(struct{}{}, testmodel.ListIdentity)
+		_ = server.RegisterProcessor(struct{}{}, testmodel.TaskIdentity)
 
 		pubsub := bahamut.NewLocalPubSubClient()
 		if err := pubsub.Connect(context.Background()); err != nil {

--- a/gateway/upstreamer/push/ping.go
+++ b/gateway/upstreamer/push/ping.go
@@ -37,6 +37,17 @@ type servicePing struct {
 	Versions     map[string]interface{}
 	Load         float64
 	APILimiters  IdentityToAPILimitersRegistry
+	Prefix       string
+}
+
+// Key returns the key for the service.
+// This is either the name or prefix/name, if any.
+func (s *servicePing) Key() string {
+	if s.Prefix != "" {
+		return s.Prefix + "/" + s.Name
+	}
+
+	return s.Name
 }
 
 type peerPing struct {

--- a/gateway/upstreamer/push/upstreamer_distribution_test.go
+++ b/gateway/upstreamer/push/upstreamer_distribution_test.go
@@ -17,7 +17,7 @@ func TestUpstreamUpstreamerDistribution(t *testing.T) {
 
 		u := NewUpstreamer(nil, "topic", "topic2")
 		u.apis = map[string][]*endpointInfo{
-			"cats": {
+			"/cats": {
 				{
 					address:  "1.1.1.1:1",
 					lastLoad: 10.0,
@@ -55,7 +55,7 @@ func TestUpstreamUpstreamerDistribution(t *testing.T) {
 
 		u := NewUpstreamer(nil, "topic", "topic2")
 		u.apis = map[string][]*endpointInfo{
-			"cats": {
+			"/cats": {
 				{
 					address:  "1.1.1.1:1",
 					lastLoad: 10.0,
@@ -92,7 +92,7 @@ func TestUpstreamUpstreamerDistribution(t *testing.T) {
 
 		u := NewUpstreamer(nil, "topic", "topic2")
 		u.apis = map[string][]*endpointInfo{
-			"cats": {
+			"/cats": {
 				{
 					address:  "1.1.1.1:1",
 					lastLoad: 10.0,
@@ -215,5 +215,4 @@ func TestLatencyBasedUpstreamer(t *testing.T) {
 		})
 
 	})
-
 }

--- a/gateway/upstreamer/push/utils.go
+++ b/gateway/upstreamer/push/utils.go
@@ -113,7 +113,7 @@ func resyncRoutes(services servicesConfig, includePrivate bool, events map[strin
 
 	for serviceName, config := range services {
 
-		_, prefix := extractPrefix(serviceName)
+		name, prefix := extractPrefix(serviceName)
 
 		for _, routes := range config.routes {
 			for _, route := range routes {
@@ -123,7 +123,7 @@ func resyncRoutes(services servicesConfig, includePrivate bool, events map[strin
 			}
 		}
 
-		if api, ok := events[serviceName]; ok {
+		if api, ok := events[name]; ok {
 			apis[prefix+"/"+api] = append([]*endpointInfo{}, config.getEndpoints()...)
 		}
 	}

--- a/gateway/upstreamer/push/utils.go
+++ b/gateway/upstreamer/push/utils.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-var vregexp = regexp.MustCompile(`^/v/\d+`)
+var vregexp = regexp.MustCompile(`/v/\d+`)
 
-func getTargetIdentity(path string) string {
+func getTargetIdentity(path string) (string, string) {
 
 	parts := strings.Split(
 		strings.TrimPrefix(
@@ -17,14 +17,20 @@ func getTargetIdentity(path string) string {
 		"/",
 	)
 
+	prefix := ""
+	if len(parts) > 1 && parts[0][0] == '_' {
+		prefix = parts[0][1:]
+		parts = append([]string{}, parts[1:]...)
+	}
+
 	switch len(parts) {
 
 	case 1:
-		return parts[0]
+		return parts[0], prefix
 	case 2:
-		return parts[0]
+		return parts[0], prefix
 	default:
-		return parts[2]
+		return parts[2], prefix
 	}
 }
 
@@ -50,10 +56,10 @@ func handleAddServicePing(services servicesConfig, sp servicePing) bool {
 		panic("handleAddServicePing received a goodbye service ping")
 	}
 
-	srv, ok := services[sp.Name]
+	srv, ok := services[sp.Key()]
 	if !ok {
-		srv = newService(sp.Name)
-		services[sp.Name] = srv
+		srv = newService(sp.Key())
+		services[sp.Key()] = srv
 	}
 
 	// In any case we poke the endpoint. This will
@@ -81,7 +87,7 @@ func handleRemoveServicePing(services servicesConfig, sp servicePing) bool {
 		panic("handleRemoveServicePing received a hello service ping")
 	}
 
-	srv, ok := services[sp.Name]
+	srv, ok := services[sp.Key()]
 	if !ok {
 		return false
 	}
@@ -96,7 +102,7 @@ func handleRemoveServicePing(services servicesConfig, sp servicePing) bool {
 		return true
 	}
 
-	delete(services, sp.Name)
+	delete(services, sp.Key())
 
 	return true
 }
@@ -107,18 +113,32 @@ func resyncRoutes(services servicesConfig, includePrivate bool, events map[strin
 
 	for serviceName, config := range services {
 
+		_, prefix := extractPrefix(serviceName)
+
 		for _, routes := range config.routes {
 			for _, route := range routes {
 				if !route.Private || includePrivate {
-					apis[route.Identity] = append([]*endpointInfo{}, config.getEndpoints()...)
+					apis[prefix+"/"+route.Identity] = append([]*endpointInfo{}, config.getEndpoints()...)
 				}
 			}
 		}
 
 		if api, ok := events[serviceName]; ok {
-			apis[api] = append([]*endpointInfo{}, config.getEndpoints()...)
+			apis[prefix+"/"+api] = append([]*endpointInfo{}, config.getEndpoints()...)
 		}
 	}
 
 	return apis
+}
+
+func extractPrefix(key string) (name string, prefix string) {
+
+	name = key
+
+	if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
+		prefix = parts[0]
+		name = parts[1]
+	}
+
+	return name, prefix
 }

--- a/gateway/upstreamer/push/utils_test.go
+++ b/gateway/upstreamer/push/utils_test.go
@@ -17,15 +17,17 @@ func Test_getTargetIdentity(t *testing.T) {
 		path string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name         string
+		args         args
+		wantIdentity string
+		wantPrefix   string
 	}{
 		{
 			"/",
 			args{
 				"/",
 			},
+			"",
 			"",
 		},
 		{
@@ -34,6 +36,7 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/users",
 			},
 			"users",
+			"",
 		},
 		{
 			"/users/id",
@@ -41,6 +44,7 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/users/id",
 			},
 			"users",
+			"",
 		},
 		{
 			"/users/id/groups",
@@ -48,6 +52,7 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/users/id/groups",
 			},
 			"groups",
+			"",
 		},
 		{
 			"/v/1/users",
@@ -55,6 +60,7 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/v/1/users",
 			},
 			"users",
+			"",
 		},
 		{
 			"/v/1/users/id",
@@ -62,6 +68,7 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/v/1/users/id",
 			},
 			"users",
+			"",
 		},
 		{
 			"/v/1/users/id/groups",
@@ -69,12 +76,74 @@ func Test_getTargetIdentity(t *testing.T) {
 				"/v/1/users/id/groups",
 			},
 			"groups",
+			"",
+		},
+		// prefixed
+		{
+			"_prefix/",
+			args{
+				"_prefix/",
+			},
+			"",
+			"prefix",
+		},
+		{
+			"_prefix/users",
+			args{
+				"_prefix/users",
+			},
+			"users",
+			"prefix",
+		},
+		{
+			"_prefix/users/id",
+			args{
+				"_prefix/users/id",
+			},
+			"users",
+			"prefix",
+		},
+		{
+			"_prefix/users/id/groups",
+			args{
+				"_prefix/users/id/groups",
+			},
+			"groups",
+			"prefix",
+		},
+		{
+			"_prefix/v/1/users",
+			args{
+				"_prefix/v/1/users",
+			},
+			"users",
+			"prefix",
+		},
+		{
+			"_prefix/v/1/users/id",
+			args{
+				"_prefix/v/1/users/id",
+			},
+			"users",
+			"prefix",
+		},
+		{
+			"_prefix/v/1/users/id/groups",
+			args{
+				"_prefix/v/1/users/id/groups",
+			},
+			"groups",
+			"prefix",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getTargetIdentity(tt.args.path); got != tt.want {
-				t.Errorf("getTargetIdentity() = %v, want %v", got, tt.want)
+			identity, prefix := getTargetIdentity(tt.args.path)
+			if identity != tt.wantIdentity {
+				t.Errorf("getTargetIdentity() identity = %v, want %v", identity, tt.wantIdentity)
+			}
+			if prefix != tt.wantPrefix {
+				t.Errorf("getTargetIdentity() prefix = %v, want %v", prefix, tt.wantPrefix)
 			}
 		})
 	}
@@ -478,7 +547,7 @@ func Test_resyncRoutes(t *testing.T) {
 				map[string]string{},
 			},
 			map[string][]*endpointInfo{
-				"cats": {
+				"/cats": {
 					{
 						address:  "1.1.1.1:1",
 						lastSeen: now,
@@ -490,7 +559,7 @@ func Test_resyncRoutes(t *testing.T) {
 						lastLoad: 0.0,
 					},
 				},
-				"kittens": {
+				"/kittens": {
 					{
 						address:  "1.1.1.1:1",
 						lastSeen: now,
@@ -548,7 +617,7 @@ func Test_resyncRoutes(t *testing.T) {
 				map[string]string{},
 			},
 			map[string][]*endpointInfo{
-				"cats": {
+				"/cats": {
 					{
 						address:  "1.1.1.1:1",
 						lastSeen: now,
@@ -606,7 +675,7 @@ func Test_resyncRoutes(t *testing.T) {
 				map[string]string{"srv1": "evt1"},
 			},
 			map[string][]*endpointInfo{
-				"cats": {
+				"/cats": {
 					{
 						address:  "1.1.1.1:1",
 						lastSeen: now,
@@ -618,7 +687,7 @@ func Test_resyncRoutes(t *testing.T) {
 						lastLoad: 0.0,
 					},
 				},
-				"evt1": {
+				"/evt1": {
 					{
 						address:  "1.1.1.1:1",
 						lastSeen: now,


### PR DESCRIPTION
This patch allows services to announce a desired prefix for the gqteway to route traffic to them.

Add OptionNotifierPrefix("myprefix") to a service, and the gateway will only route apis prefixed by "_myprefix" (the "_" is mandatory in the URL in order to efficiently distinguish prefixes)

It also adds OptionNotifierAPIPrivateOverrides that allows to change the private flag for a particular route.