### PR TITLE
fixed/metrics/prometheus: correctly handle prefix

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -55,7 +55,7 @@ type fakeMetricManager struct {
 	unregisterTCPConnectionCalled int64
 }
 
-func (m *fakeMetricManager) MeasureRequest(method string, url string) bahamut.FinishMeasurementFunc {
+func (m *fakeMetricManager) MeasureRequest(method string, path string) bahamut.FinishMeasurementFunc {
 	return func(code int, span opentracing.Span) time.Duration { return 0 }
 }
 

--- a/health_server_test.go
+++ b/health_server_test.go
@@ -37,7 +37,7 @@ func freePort() (port int) {
 // A MetricsManager handles Prometheus Metrics Management
 type testMetricsManager struct{}
 
-func (m *testMetricsManager) MeasureRequest(method string, url string) FinishMeasurementFunc {
+func (m *testMetricsManager) MeasureRequest(method string, path string) FinishMeasurementFunc {
 	return nil
 }
 func (m *testMetricsManager) RegisterWSConnection()    {}

--- a/metrics.go
+++ b/metrics.go
@@ -23,7 +23,7 @@ type FinishMeasurementFunc func(code int, span opentracing.Span) time.Duration
 
 // A MetricsManager handles Prometheus Metrics Management
 type MetricsManager interface {
-	MeasureRequest(method string, url string) FinishMeasurementFunc
+	MeasureRequest(method string, path string) FinishMeasurementFunc
 	RegisterWSConnection()
 	UnregisterWSConnection()
 	RegisterTCPConnection()

--- a/metrics_prometheus_test.go
+++ b/metrics_prometheus_test.go
@@ -69,10 +69,53 @@ func Test_sanitizeURL(t *testing.T) {
 			},
 			"/toto/:id/titi",
 		},
+
+		{
+			"test /_prefix/toto",
+			args{
+				"/_prefix/toto",
+			},
+			"/_prefix/toto",
+		},
+		{
+			"test /_prefix/v/1/toto",
+			args{
+				"/_prefix/v/1/toto",
+			},
+			"/_prefix/toto",
+		},
+		{
+			"test /_prefix/toto/xxxxxxx",
+			args{
+				"/_prefix/toto/xxxxxxx",
+			},
+			"/_prefix/toto/:id",
+		},
+		{
+			"test /_prefix/v/1/toto/xxxxxxx",
+			args{
+				"/_prefix/v/1/toto/xxxxxxx",
+			},
+			"/_prefix/toto/:id",
+		},
+		{
+			"test /_prefix/toto/xxxxxxx/titi",
+			args{
+				"/_prefix/toto/xxxxxxx/titi",
+			},
+			"/_prefix/toto/:id/titi",
+		},
+		{
+			"test /_prefix/v/1/toto/xxxxxxx/titi",
+			args{
+				"/_prefix/v/1/toto/xxxxxxx/titi",
+			},
+			"/_prefix/toto/:id/titi",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := sanitizeURL(tt.args.url); got != tt.want {
+			if got := sanitizePath(tt.args.url); got != tt.want {
 				t.Errorf("sanitizeURL() = %v, want %v", got, tt.want)
 			}
 		})
@@ -104,7 +147,7 @@ func TestMeasureRequest(t *testing.T) {
 
 		Convey("When I call measure a 502 request", func() {
 
-			f := pmm.MeasureRequest("GET", "http://toto.com/id/toto")
+			f := pmm.MeasureRequest("GET", "/toto/id")
 			f(502, nil)
 
 			data, _ := r.Gather()
@@ -114,7 +157,7 @@ func TestMeasureRequest(t *testing.T) {
 				So(data[0].GetMetric()[0].Label[0].String(), ShouldEqual, `name:"code" value:"502" `)
 				So(data[0].GetMetric()[0].Label[1].String(), ShouldEqual, `name:"method" value:"GET" `)
 				So(data[0].GetMetric()[0].Label[2].String(), ShouldEqual, `name:"trace" value:"unknown" `)
-				So(data[0].GetMetric()[0].Label[3].String(), ShouldEqual, `name:"url" value:"http://:id/id/toto" `)
+				So(data[0].GetMetric()[0].Label[3].String(), ShouldEqual, `name:"url" value:"/toto/:id" `)
 			})
 		})
 	})


### PR DESCRIPTION
This patches fixes a bug where the sanitization function of the prometheus metric manager was not correctly handling the given path if it was containing a '_prefix'. This patch fixes this issue and adds tests.

The parameter 'url' of the interface MetricManager.MeasureRequest has also been renamed to 'path' for better usage clarity.