### PR TITLE
fix data race and remove oxy v1

### DIFF
--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/mailgun/multibuf"
 	// nolint:revive // Allow dot imports for readability in tests
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/vulcand/oxy/ratelimit"
 	"github.com/vulcand/oxy/v2/connlimit"
+	"github.com/vulcand/oxy/v2/ratelimit"
 	"go.aporeto.io/elemental"
 )
 

--- a/gateway/upstreamer/push/notifier_test.go
+++ b/gateway/upstreamer/push/notifier_test.go
@@ -83,13 +83,12 @@ func TestNonNotifier(t *testing.T) {
 					So(err, ShouldBeNil)
 				})
 
-				var p *bahamut.Publication
-				select {
-				case <-time.After(300 * time.Millisecond):
-				case p = <-pubCh:
-				}
-
 				Convey("Then the pubsub should have received a push", func() {
+					var p *bahamut.Publication
+					select {
+					case <-time.After(300 * time.Millisecond):
+					case p = <-pubCh:
+					}
 
 					So(p, ShouldNotBeNil)
 
@@ -117,7 +116,7 @@ func TestNonNotifier(t *testing.T) {
 					}
 					So(checked, ShouldEqual, 5)
 
-					Convey("Then I wait 1.5sec and I should get another pusb", func() {
+					Convey("Then I wait 1.5sec and I should get another push", func() {
 
 						var p *bahamut.Publication
 						select {
@@ -253,7 +252,7 @@ func TestPrefixedNotifier(t *testing.T) {
 					So(sping.Status, ShouldEqual, entityStatusHello)
 					So(sping.Prefix, ShouldEqual, "prefix")
 
-					Convey("Then I wait 1.5sec and I should get another pusb", func() {
+					Convey("Then I wait 1.5sec and I should get another push", func() {
 
 						var p *bahamut.Publication
 						select {

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.1
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/valyala/tcplisten v1.0.0
-	github.com/vulcand/oxy v1.4.2
 	github.com/vulcand/oxy/v2 v2.0.0-20221121151423-d5cb734e4467
 	go.uber.org/zap v1.24.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -805,8 +805,6 @@ github.com/ugorji/go/codec v1.2.9 h1:rmenucSohSTiyL09Y+l2OCk+FrMxGMzho2+tjr5ticU
 github.com/ugorji/go/codec v1.2.9/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
-github.com/vulcand/oxy v1.4.2 h1:KibUVdKrwy7eXR3uHS2pYoZ9dCzKVcgDNHD2jkPZmxU=
-github.com/vulcand/oxy v1.4.2/go.mod h1:Yq8OBb0XWU/7nPSglwUH5LS2Pcp4yvad8SVayobZbSo=
 github.com/vulcand/oxy/v2 v2.0.0-20221121151423-d5cb734e4467 h1:Dbv3KJLgwtDKLpCZzTf1ISeG5ZYudPaLfTdYi4O2dSU=
 github.com/vulcand/oxy/v2 v2.0.0-20221121151423-d5cb734e4467/go.mod h1:0kOEB8mKzSeGHknF53gTM47UEvQnPoAPnM+58baqn2o=
 github.com/vulcand/predicate v1.2.0 h1:uFsW1gcnnR7R+QTID+FVcs0sSYlIGntoGOTb3rQJt50=

--- a/publication.go
+++ b/publication.go
@@ -83,6 +83,8 @@ func (p *Publication) Encode(o any) error {
 
 // EncodeWithEncoding the given object into the publication using the given encoding.
 func (p *Publication) EncodeWithEncoding(o any, encoding elemental.EncodingType) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
 	data, err := elemental.Encode(encoding, o)
 	if err != nil {
@@ -147,6 +149,8 @@ func (p *Publication) Span() opentracing.Span {
 
 // Duplicate returns a copy of the publication
 func (p *Publication) Duplicate() *Publication {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
 	pub := NewPublication(p.Topic)
 	pub.Data = p.Data


### PR DESCRIPTION
## Description

1. removes the final dependancy on github.com/vulcand/oxy V1 which requires gocheck and that requires Bazaar VCS.  Oxy V2 is the current version and does not import gocheck, thus eliminating the need for Bazaar VCS (bzr) 
2. Fixes a data race condition in the publisher

## Motivation and Context
1. removes the need for the bazaar binary when everything else uses git 
2. Fixes a data race in the publisher. 

## How Has This Been Tested?

using `make test` 

Output after the fix is applied: 
```shell
$ make test
go test ./... -race -cover -covermode=atomic -coverprofile=unit_coverage.out
# go.aporeto.io/bahamut/gateway/upstreamer/push.test
ok      go.aporeto.io/bahamut   107.834s        coverage: 90.8% of statements
ok      go.aporeto.io/bahamut/authorizer/mtls   51.784s coverage: 97.7% of statements
ok      go.aporeto.io/bahamut/authorizer/simple 51.676s coverage: 100.0% of statements
ok      go.aporeto.io/bahamut/gateway   53.187s coverage: 93.2% of statements
ok      go.aporeto.io/bahamut/gateway/upstreamer/push   86.967s coverage: 94.2% of statements
```

## Screenshots showing the data race bug 
```shell
WARNING: DATA RACE
Write at 0x00c0003b01d8 by goroutine 20:
  go.aporeto.io/bahamut.(*Publication).EncodeWithEncoding()
      /Users/bonn/Repos/bahamut/publication.go:92 +0x6c
  go.aporeto.io/bahamut.(*Publication).Encode()
      /Users/bonn/Repos/bahamut/publication.go:81 +0x44
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2.(*Notifier).MakeStartHook.3.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:115 +0x2e8

Previous read at 0x00c0003b01d8 by goroutine 21:
  go.aporeto.io/bahamut.(*Publication).Duplicate()
      /Users/bonn/Repos/bahamut/publication.go:152 +0x18c
  go.aporeto.io/bahamut.(*localPubSub).listen.func1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:135 +0x3e8
  go.aporeto.io/bahamut.(*localPubSub).listen.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:136 +0x54

Goroutine 20 (running) created at:
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2.(*Notifier).MakeStartHook.3()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:103 +0x6a0
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:80 +0x120
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:73 +0x5e4
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:39 +0x5a0
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.rootConvey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:112 +0x16c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0x3c
  github.com/jtolds/gls._m()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:108 +0x38
  github.com/jtolds/gls.github_com_jtolds_gls_markS()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:56 +0x30
  github.com/jtolds/gls.addStackTag()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:49 +0x130
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0xb8
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.rootConvey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:107 +0x4a0
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:76 +0x98
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:17 +0x98
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1742 +0x40

Goroutine 21 (finished) created at:
  go.aporeto.io/bahamut.(*localPubSub).listen()
      /Users/bonn/Repos/bahamut/pubsub_local.go:133 +0x54c
  go.aporeto.io/bahamut.(*localPubSub).Connect.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:80 +0x34
==================
==================
WARNING: DATA RACE
Write at 0x00c0003b01c8 by goroutine 20:
  go.aporeto.io/bahamut.(*Publication).EncodeWithEncoding()
      /Users/bonn/Repos/bahamut/publication.go:93 +0xb4
  go.aporeto.io/bahamut.(*Publication).Encode()
      /Users/bonn/Repos/bahamut/publication.go:81 +0x44
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2.(*Notifier).MakeStartHook.3.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:115 +0x2e8

Previous read at 0x00c0003b01c8 by goroutine 21:
  go.aporeto.io/bahamut.(*Publication).Duplicate()
      /Users/bonn/Repos/bahamut/publication.go:156 +0x2f4
  go.aporeto.io/bahamut.(*localPubSub).listen.func1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:135 +0x3e8
  go.aporeto.io/bahamut.(*localPubSub).listen.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:136 +0x54

Goroutine 20 (running) created at:
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2.(*Notifier).MakeStartHook.3()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:103 +0x6a0
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1.2()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:80 +0x120
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:73 +0x5e4
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier.func1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:39 +0x5a0
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.rootConvey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:112 +0x16c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0x3c
  github.com/jtolds/gls._m()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:108 +0x38
  github.com/jtolds/gls.github_com_jtolds_gls_markS()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:56 +0x30
  github.com/jtolds/gls.addStackTag()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:49 +0x130
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0xb8
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.rootConvey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:107 +0x4a0
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:76 +0x98
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestNonNotifier()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:17 +0x98
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1742 +0x40

Goroutine 21 (finished) created at:
  go.aporeto.io/bahamut.(*localPubSub).listen()
      /Users/bonn/Repos/bahamut/pubsub_local.go:133 +0x54c
  go.aporeto.io/bahamut.(*localPubSub).Connect.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:80 +0x34
==================
✔✔✔✔✔✔✔✔✔✔
      When I call MakeStopHook and call the hook 
        Then err should be nil ✔✔✔✔✔✔
        Then the pubsub should have received a push ✔✔✔✔✔✔


70 total assertions

    testing.go:1398: race detected during execution of test
--- FAIL: TestNonNotifier (3.01s)
=== RUN   TestPrefixedNotifier

  Given I have a pubsub client and a bahamut server 
    When I call NewNotifier 
      Then n should be correct ✔✔✔✔✔✔✔
      When I call MakeStartHook and call the hook 
        Then err should be nil ✔
        Then the pubsub should have received a push ✔✔✔✔✔✔
          Then I wait 1.5sec and I should get another pusb ==================
WARNING: DATA RACE
Write at 0x00c0000e0e58 by goroutine 40:
  go.aporeto.io/bahamut.(*Publication).EncodeWithEncoding()
      /Users/bonn/Repos/bahamut/publication.go:92 +0x6c
  go.aporeto.io/bahamut.(*Publication).Encode()
      /Users/bonn/Repos/bahamut/publication.go:81 +0x44
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2.(*Notifier).MakeStartHook.3.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:115 +0x2e8

Previous read at 0x00c0000e0e58 by goroutine 41:
  go.aporeto.io/bahamut.(*Publication).Duplicate()
      /Users/bonn/Repos/bahamut/publication.go:152 +0x18c
  go.aporeto.io/bahamut.(*localPubSub).listen.func1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:135 +0x3e8
  go.aporeto.io/bahamut.(*localPubSub).listen.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:136 +0x54

Goroutine 40 (running) created at:
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2.(*Notifier).MakeStartHook.3()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:103 +0x6a0
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:229 +0x120
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:222 +0x4b4
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:198 +0x488
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.rootConvey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:112 +0x16c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0x3c
  github.com/jtolds/gls._m()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:108 +0x38
  github.com/jtolds/gls.github_com_jtolds_gls_markS()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:56 +0x30
  github.com/jtolds/gls.addStackTag()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:49 +0x130
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0xb8
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.rootConvey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:107 +0x4a0
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:76 +0x98
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:179 +0x98
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1742 +0x40

Goroutine 41 (finished) created at:
  go.aporeto.io/bahamut.(*localPubSub).listen()
      /Users/bonn/Repos/bahamut/pubsub_local.go:133 +0x54c
  go.aporeto.io/bahamut.(*localPubSub).Connect.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:80 +0x34
==================
==================
WARNING: DATA RACE
Write at 0x00c0000e0e48 by goroutine 40:
  go.aporeto.io/bahamut.(*Publication).EncodeWithEncoding()
      /Users/bonn/Repos/bahamut/publication.go:93 +0xb4
  go.aporeto.io/bahamut.(*Publication).Encode()
      /Users/bonn/Repos/bahamut/publication.go:81 +0x44
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2.(*Notifier).MakeStartHook.3.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:115 +0x2e8

Previous read at 0x00c0000e0e48 by goroutine 41:
  go.aporeto.io/bahamut.(*Publication).Duplicate()
      /Users/bonn/Repos/bahamut/publication.go:156 +0x2f4
  go.aporeto.io/bahamut.(*localPubSub).listen.func1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:135 +0x3e8
  go.aporeto.io/bahamut.(*localPubSub).listen.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:136 +0x54

Goroutine 40 (running) created at:
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2.(*Notifier).MakeStartHook.3()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier.go:103 +0x6a0
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1.2()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:229 +0x120
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1.1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:222 +0x4b4
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.(*context).Convey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:166 +0x6c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:19 +0x164
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.(*context).Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:165 +0x62c
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:78 +0x84
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier.func1()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:198 +0x488
  github.com/smartystreets/goconvey/convey.discover.parseAction.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/discovery.go:89 +0x30
  github.com/smartystreets/goconvey/convey.(*context).conveyInner()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:279 +0x1f0
  github.com/smartystreets/goconvey/convey.rootConvey.func1()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:112 +0x16c
  github.com/jtolds/gls.(*ContextManager).SetValues.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:97 +0x4ac
  github.com/jtolds/gls.EnsureGoroutineId.func1()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0x3c
  github.com/jtolds/gls._m()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:108 +0x38
  github.com/jtolds/gls.github_com_jtolds_gls_markS()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:56 +0x30
  github.com/jtolds/gls.addStackTag()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/stack_tags.go:49 +0x130
  github.com/jtolds/gls.EnsureGoroutineId()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/gid.go:24 +0xb8
  github.com/jtolds/gls.(*ContextManager).SetValues()
      /Volumes/Go/pkg/mod/github.com/jtolds/gls@v4.20.0+incompatible/context.go:63 +0x260
  github.com/smartystreets/goconvey/convey.rootConvey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/context.go:107 +0x4a0
  github.com/smartystreets/goconvey/convey.Convey()
      /Volumes/Go/pkg/mod/github.com/smartystreets/goconvey@v1.7.2/convey/doc.go:76 +0x98
  go.aporeto.io/bahamut/gateway/upstreamer/push.TestPrefixedNotifier()
      /Users/bonn/Repos/bahamut/gateway/upstreamer/push/notifier_test.go:179 +0x98
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.5/libexec/src/testing/testing.go:1742 +0x40

Goroutine 41 (finished) created at:
  go.aporeto.io/bahamut.(*localPubSub).listen()
      /Users/bonn/Repos/bahamut/pubsub_local.go:133 +0x54c
  go.aporeto.io/bahamut.(*localPubSub).Connect.gowrap1()
      /Users/bonn/Repos/bahamut/pubsub_local.go:80 +0x34
==================
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
